### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ config := http_client.Config{
 	Logger:                http_client.NewDefaultLogger(),
 	MaxConcurrentRequests: maxConcurrentRequestsAllowed,
 	TokenLifespan:         defaultTokenLifespan,
-	BufferPeriod:          defaultBufferPeriod,
+	TokenRefreshBufferPeriod: defaultBufferPeriod,
 }
 ```
 

--- a/examples/Authentication/GetBearerTokenAuthWithClientCredentialConfigFile/GetBearerTokenWithClientCredentialConfigFile.go
+++ b/examples/Authentication/GetBearerTokenAuthWithClientCredentialConfigFile/GetBearerTokenWithClientCredentialConfigFile.go
@@ -27,7 +27,10 @@ func main() {
 	}
 
 	// Create a new client instance using the loaded InstanceName
-	client := http_client.NewClient(authConfig.InstanceName, config, nil)
+	client, err := http_client.NewClient(authConfig.InstanceName, config, nil)
+	if err != nil {
+		log.Fatalf("Failed to create new client: %v", err)
+	}
 
 	// Set OAuth credentials for the client
 	oAuthCreds := http_client.OAuthCredentials{

--- a/examples/Authentication/GetBearerTokenAuthWithClientCredentials/GetBearerTokenAuthWithClientCredentials.go
+++ b/examples/Authentication/GetBearerTokenAuthWithClientCredentials/GetBearerTokenAuthWithClientCredentials.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
 )
@@ -19,7 +20,10 @@ func main() {
 	}
 
 	// Create a new client instance
-	client := http_client.NewClient(baseURL, config, nil)
+	client, err := http_client.NewClient(baseURL, config, nil)
+	if err != nil {
+		log.Fatalf("Failed to create new client: %v", err)
+	}
 
 	// Set OAuth credentials for the client
 	oAuthCreds := http_client.OAuthCredentials{

--- a/examples/Authentication/GetBearerTokenAuthWithUserCredentialConfigFile/GetBearerTokenAuthWithUserCredentialConfigFile.go
+++ b/examples/Authentication/GetBearerTokenAuthWithUserCredentialConfigFile/GetBearerTokenAuthWithUserCredentialConfigFile.go
@@ -24,7 +24,10 @@ func main() {
 	}
 
 	// Create a new client instance using the loaded InstanceName
-	client := http_client.NewClient(authConfig.InstanceName, config, nil)
+	client, err := http_client.NewClient(authConfig.InstanceName, config, nil)
+	if err != nil {
+		log.Fatalf("Failed to create new client: %v", err)
+	}
 
 	// Set BearerTokenAuthCredentials
 	client.SetBearerTokenAuthCredentials(http_client.BearerTokenAuthCredentials{

--- a/examples/Authentication/GetBearerTokenAuthWithUserCredentials/GetBearerTokenAuthWithUserCredentials.go
+++ b/examples/Authentication/GetBearerTokenAuthWithUserCredentials/GetBearerTokenAuthWithUserCredentials.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
 )
@@ -19,7 +20,10 @@ func main() {
 	}
 
 	// Create a new client instance using the provided BaseURL
-	client := http_client.NewClient(baseURL, config, nil)
+	client, err := http_client.NewClient(baseURL, config, nil)
+	if err != nil {
+		log.Fatalf("Failed to create new client: %v", err)
+	}
 
 	// Set BearerTokenAuthCredentials
 	client.SetBearerTokenAuthCredentials(http_client.BearerTokenAuthCredentials{
@@ -28,7 +32,7 @@ func main() {
 	})
 
 	// Call the ObtainToken function to get a bearer token
-	err := client.ObtainToken()
+	err = client.ObtainToken()
 	if err != nil {
 		fmt.Println("Error obtaining token:", err)
 		return

--- a/examples/accounts/CreateAccountByID/CreateAccountByID.go
+++ b/examples/accounts/CreateAccountByID/CreateAccountByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instance

--- a/examples/accounts/CreateAccountByID/CreateAccountByID.go
+++ b/examples/accounts/CreateAccountByID/CreateAccountByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instance

--- a/examples/accounts/CreateAccountGroupByID/CreateAccountGroupByID.go
+++ b/examples/accounts/CreateAccountGroupByID/CreateAccountGroupByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/CreateAccountGroupByID/CreateAccountGroupByID.go
+++ b/examples/accounts/CreateAccountGroupByID/CreateAccountGroupByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountByID/DeleteAccountByID.go
+++ b/examples/accounts/DeleteAccountByID/DeleteAccountByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountByID/DeleteAccountByID.go
+++ b/examples/accounts/DeleteAccountByID/DeleteAccountByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountByName/DeleteAccountByName.go
+++ b/examples/accounts/DeleteAccountByName/DeleteAccountByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountByName/DeleteAccountByName.go
+++ b/examples/accounts/DeleteAccountByName/DeleteAccountByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountGroupByID/DeleteAccountGroupByID.go
+++ b/examples/accounts/DeleteAccountGroupByID/DeleteAccountGroupByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountGroupByID/DeleteAccountGroupByID.go
+++ b/examples/accounts/DeleteAccountGroupByID/DeleteAccountGroupByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountGroupByName/DeleteAccountGroupByName.go
+++ b/examples/accounts/DeleteAccountGroupByName/DeleteAccountGroupByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/DeleteAccountGroupByName/DeleteAccountGroupByName.go
+++ b/examples/accounts/DeleteAccountGroupByName/DeleteAccountGroupByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountByID/GetAccountByID.go
+++ b/examples/accounts/GetAccountByID/GetAccountByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountByID/GetAccountByID.go
+++ b/examples/accounts/GetAccountByID/GetAccountByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountByName/GetAccountByName.go
+++ b/examples/accounts/GetAccountByName/GetAccountByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountByName/GetAccountByName.go
+++ b/examples/accounts/GetAccountByName/GetAccountByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountGroupByID/GetAccountGroupByID.go
+++ b/examples/accounts/GetAccountGroupByID/GetAccountGroupByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountGroupByID/GetAccountGroupByID.go
+++ b/examples/accounts/GetAccountGroupByID/GetAccountGroupByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountGroupByName/GetAccountGroupByName.go
+++ b/examples/accounts/GetAccountGroupByName/GetAccountGroupByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccountGroupByName/GetAccountGroupByName.go
+++ b/examples/accounts/GetAccountGroupByName/GetAccountGroupByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccounts/GetAccounts.go
+++ b/examples/accounts/GetAccounts/GetAccounts.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/GetAccounts/GetAccounts.go
+++ b/examples/accounts/GetAccounts/GetAccounts.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountByID/UpdateAccountByID.go
+++ b/examples/accounts/UpdateAccountByID/UpdateAccountByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountByID/UpdateAccountByID.go
+++ b/examples/accounts/UpdateAccountByID/UpdateAccountByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountByName/UpdateAccountByName.go
+++ b/examples/accounts/UpdateAccountByName/UpdateAccountByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountByName/UpdateAccountByName.go
+++ b/examples/accounts/UpdateAccountByName/UpdateAccountByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountGroupByID/UpdateAccountGroupByID.go
+++ b/examples/accounts/UpdateAccountGroupByID/UpdateAccountGroupByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountGroupByID/UpdateAccountGroupByID.go
+++ b/examples/accounts/UpdateAccountGroupByID/UpdateAccountGroupByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountGroupByName/UpdateAccountGroupByName.go
+++ b/examples/accounts/UpdateAccountGroupByName/UpdateAccountGroupByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/accounts/UpdateAccountGroupByName/UpdateAccountGroupByName.go
+++ b/examples/accounts/UpdateAccountGroupByName/UpdateAccountGroupByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/CreateAllowedFileExtension/CreateAllowedFileExtension.go
+++ b/examples/allowed_file_extensions/CreateAllowedFileExtension/CreateAllowedFileExtension.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/CreateAllowedFileExtension/CreateAllowedFileExtension.go
+++ b/examples/allowed_file_extensions/CreateAllowedFileExtension/CreateAllowedFileExtension.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/DeleteAllowedFileExtensionByID/DeleteAllowedFileExtensionByID.go
+++ b/examples/allowed_file_extensions/DeleteAllowedFileExtensionByID/DeleteAllowedFileExtensionByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/DeleteAllowedFileExtensionByID/DeleteAllowedFileExtensionByID.go
+++ b/examples/allowed_file_extensions/DeleteAllowedFileExtensionByID/DeleteAllowedFileExtensionByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/DeleteAllowedFileExtensionByName/DeleteAllowedFileExtensionByName.go
+++ b/examples/allowed_file_extensions/DeleteAllowedFileExtensionByName/DeleteAllowedFileExtensionByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/DeleteAllowedFileExtensionByName/DeleteAllowedFileExtensionByName.go
+++ b/examples/allowed_file_extensions/DeleteAllowedFileExtensionByName/DeleteAllowedFileExtensionByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensionByName/GetAllowedFileExtensionByName.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensionByName/GetAllowedFileExtensionByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensionByName/GetAllowedFileExtensionByName.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensionByName/GetAllowedFileExtensionByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensions/GetAllowedFileExtensions.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensions/GetAllowedFileExtensions.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/allowed_file_extensions/GetAllowedFileExtensions/GetAllowedFileExtensions.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensions/GetAllowedFileExtensions.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildingByID/GetBuildingByID.go
+++ b/examples/buildings/GetBuildingByID/GetBuildingByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildingByID/GetBuildingByID.go
+++ b/examples/buildings/GetBuildingByID/GetBuildingByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildings/GetBuildings.go
+++ b/examples/buildings/GetBuildings/GetBuildings.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildings/GetBuildings.go
+++ b/examples/buildings/GetBuildings/GetBuildings.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildingsByName/GetBuildingsByName.go
+++ b/examples/buildings/GetBuildingsByName/GetBuildingsByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/buildings/GetBuildingsByName/GetBuildingsByName.go
+++ b/examples/buildings/GetBuildingsByName/GetBuildingsByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/CreateComputerGroup/CreateComputerGroup.go
+++ b/examples/computer_groups/CreateComputerGroup/CreateComputerGroup.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/CreateComputerGroup/CreateComputerGroup.go
+++ b/examples/computer_groups/CreateComputerGroup/CreateComputerGroup.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/DeleteComputerGroupByID/DeleteComputerGroupByID.go
+++ b/examples/computer_groups/DeleteComputerGroupByID/DeleteComputerGroupByID.go
@@ -26,14 +26,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/DeleteComputerGroupByID/DeleteComputerGroupByID.go
+++ b/examples/computer_groups/DeleteComputerGroupByID/DeleteComputerGroupByID.go
@@ -2,16 +2,8 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -26,14 +18,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/DeleteComputerGroupByName/DeleteComputerGroupByName.go
+++ b/examples/computer_groups/DeleteComputerGroupByName/DeleteComputerGroupByName.go
@@ -26,14 +26,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/DeleteComputerGroupByName/DeleteComputerGroupByName.go
+++ b/examples/computer_groups/DeleteComputerGroupByName/DeleteComputerGroupByName.go
@@ -2,16 +2,8 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -26,14 +18,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroupByID/GetComputerGroupByID.go
+++ b/examples/computer_groups/GetComputerGroupByID/GetComputerGroupByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroupByID/GetComputerGroupByID.go
+++ b/examples/computer_groups/GetComputerGroupByID/GetComputerGroupByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroupByName/GetComputerGroupByName.go
+++ b/examples/computer_groups/GetComputerGroupByName/GetComputerGroupByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroupByName/GetComputerGroupByName.go
+++ b/examples/computer_groups/GetComputerGroupByName/GetComputerGroupByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroups/GetComputerGroups.go
+++ b/examples/computer_groups/GetComputerGroups/GetComputerGroups.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/GetComputerGroups/GetComputerGroups.go
+++ b/examples/computer_groups/GetComputerGroups/GetComputerGroups.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/UpdateComputerGroupByID/UpdateComputerGroupByID.go
+++ b/examples/computer_groups/UpdateComputerGroupByID/UpdateComputerGroupByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/UpdateComputerGroupByID/UpdateComputerGroupByID.go
+++ b/examples/computer_groups/UpdateComputerGroupByID/UpdateComputerGroupByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/UpdateComputerGroupByName/UpdateComputerGroupByName.go
+++ b/examples/computer_groups/UpdateComputerGroupByName/UpdateComputerGroupByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/computer_groups/UpdateComputerGroupByName/UpdateComputerGroupByName.go
+++ b/examples/computer_groups/UpdateComputerGroupByName/UpdateComputerGroupByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/concurrency/OauthConcurrentSessionTester/OauthConcurrentSessionTester.go
+++ b/examples/concurrency/OauthConcurrentSessionTester/OauthConcurrentSessionTester.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/CreateDepartment/CreateDepartment.go
+++ b/examples/departments/CreateDepartment/CreateDepartment.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/CreateDepartment/CreateDepartment.go
+++ b/examples/departments/CreateDepartment/CreateDepartment.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/DeleteDepartmentByID/DeleteDepartmentByID.go
+++ b/examples/departments/DeleteDepartmentByID/DeleteDepartmentByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/DeleteDepartmentByID/DeleteDepartmentByID.go
+++ b/examples/departments/DeleteDepartmentByID/DeleteDepartmentByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/DeleteDepartmentByName/DeleteDepartmentByName.go
+++ b/examples/departments/DeleteDepartmentByName/DeleteDepartmentByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/DeleteDepartmentByName/DeleteDepartmentByName.go
+++ b/examples/departments/DeleteDepartmentByName/DeleteDepartmentByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentByID/GetDepartmentByID.go
+++ b/examples/departments/GetDepartmentByID/GetDepartmentByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentByID/GetDepartmentByID.go
+++ b/examples/departments/GetDepartmentByID/GetDepartmentByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentByName/GetDepartmentByName.go
+++ b/examples/departments/GetDepartmentByName/GetDepartmentByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentByName/GetDepartmentByName.go
+++ b/examples/departments/GetDepartmentByName/GetDepartmentByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentIdByName/GetDepartmentIdByName.go
+++ b/examples/departments/GetDepartmentIdByName/GetDepartmentIdByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartmentIdByName/GetDepartmentIdByName.go
+++ b/examples/departments/GetDepartmentIdByName/GetDepartmentIdByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartments/GetDepartments.go
+++ b/examples/departments/GetDepartments/GetDepartments.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/GetDepartments/GetDepartments.go
+++ b/examples/departments/GetDepartments/GetDepartments.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/UpdateDepartmentByID/UpdateDepartmentByID.go
+++ b/examples/departments/UpdateDepartmentByID/UpdateDepartmentByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/UpdateDepartmentByID/UpdateDepartmentByID.go
+++ b/examples/departments/UpdateDepartmentByID/UpdateDepartmentByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/UpdateDepartmentByName/UpdateDepartmentByName.go
+++ b/examples/departments/UpdateDepartmentByName/UpdateDepartmentByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/departments/UpdateDepartmentByName/UpdateDepartmentByName.go
+++ b/examples/departments/UpdateDepartmentByName/UpdateDepartmentByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/CreateApiIntegration/CreateApiIntegration.go
+++ b/examples/jamf_api_integrations/CreateApiIntegration/CreateApiIntegration.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/CreateApiIntegration/CreateApiIntegration.go
+++ b/examples/jamf_api_integrations/CreateApiIntegration/CreateApiIntegration.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/DeleteApiIntegrationByID/DeleteApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/DeleteApiIntegrationByID/DeleteApiIntegrationByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/DeleteApiIntegrationByID/DeleteApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/DeleteApiIntegrationByID/DeleteApiIntegrationByID.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/DeleteApiIntegrationByName/DeleteApiIntegrationByName.go
+++ b/examples/jamf_api_integrations/DeleteApiIntegrationByName/DeleteApiIntegrationByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/DeleteApiIntegrationByName/DeleteApiIntegrationByName.go
+++ b/examples/jamf_api_integrations/DeleteApiIntegrationByName/DeleteApiIntegrationByName.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrationByID/GetApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/GetApiIntegrationByID/GetApiIntegrationByID.go
@@ -29,14 +29,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrationByID/GetApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/GetApiIntegrationByID/GetApiIntegrationByID.go
@@ -29,14 +29,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrationNameByID/GetApiIntegrationNameByID.go
+++ b/examples/jamf_api_integrations/GetApiIntegrationNameByID/GetApiIntegrationNameByID.go
@@ -29,14 +29,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrationNameByID/GetApiIntegrationNameByID.go
+++ b/examples/jamf_api_integrations/GetApiIntegrationNameByID/GetApiIntegrationNameByID.go
@@ -29,14 +29,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
+++ b/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
+++ b/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
@@ -4,16 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateApiIntegrationByID/UpdateApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/UpdateApiIntegrationByID/UpdateApiIntegrationByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateApiIntegrationByID/UpdateApiIntegrationByID.go
+++ b/examples/jamf_api_integrations/UpdateApiIntegrationByID/UpdateApiIntegrationByID.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateApiIntegrationByName/UpdateApiIntegrationByName.go
+++ b/examples/jamf_api_integrations/UpdateApiIntegrationByName/UpdateApiIntegrationByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateApiIntegrationByName/UpdateApiIntegrationByName.go
+++ b/examples/jamf_api_integrations/UpdateApiIntegrationByName/UpdateApiIntegrationByName.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateClientCredentialsByApiIntegrationID/UpdateClientCredentialsByApiIntegrationID.go
+++ b/examples/jamf_api_integrations/UpdateClientCredentialsByApiIntegrationID/UpdateClientCredentialsByApiIntegrationID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_integrations/UpdateClientCredentialsByApiIntegrationID/UpdateClientCredentialsByApiIntegrationID.go
+++ b/examples/jamf_api_integrations/UpdateClientCredentialsByApiIntegrationID/UpdateClientCredentialsByApiIntegrationID.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/CreateJamfApiRole/CreateJamfApiRole.go
+++ b/examples/jamf_api_roles/CreateJamfApiRole/CreateJamfApiRole.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/CreateJamfApiRole/CreateJamfApiRole.go
+++ b/examples/jamf_api_roles/CreateJamfApiRole/CreateJamfApiRole.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/DeleteJamfApiRoleByID/DeleteJamfApiRoleByID.go
+++ b/examples/jamf_api_roles/DeleteJamfApiRoleByID/DeleteJamfApiRoleByID.go
@@ -26,14 +26,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/DeleteJamfApiRoleByID/DeleteJamfApiRoleByID.go
+++ b/examples/jamf_api_roles/DeleteJamfApiRoleByID/DeleteJamfApiRoleByID.go
@@ -2,16 +2,8 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -26,14 +18,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/DeleteJamfApiRoleByName/DeleteJamfApiRoleByName.go
+++ b/examples/jamf_api_roles/DeleteJamfApiRoleByName/DeleteJamfApiRoleByName.go
@@ -26,14 +26,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/DeleteJamfApiRoleByName/DeleteJamfApiRoleByName.go
+++ b/examples/jamf_api_roles/DeleteJamfApiRoleByName/DeleteJamfApiRoleByName.go
@@ -2,16 +2,8 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -26,14 +18,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
+++ b/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
+++ b/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
@@ -4,16 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfApiRolesByID/GetJamfApiRolesByID.go
+++ b/examples/jamf_api_roles/GetJamfApiRolesByID/GetJamfApiRolesByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfApiRolesByID/GetJamfApiRolesByID.go
+++ b/examples/jamf_api_roles/GetJamfApiRolesByID/GetJamfApiRolesByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfApiRolesNameById/GetJamfApiRolesNameById.go
+++ b/examples/jamf_api_roles/GetJamfApiRolesNameById/GetJamfApiRolesNameById.go
@@ -29,14 +29,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/GetJamfApiRolesNameById/GetJamfApiRolesNameById.go
+++ b/examples/jamf_api_roles/GetJamfApiRolesNameById/GetJamfApiRolesNameById.go
@@ -29,14 +29,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/UpdateJamfApiRoleByID/UpdateJamfApiRoleByID.go
+++ b/examples/jamf_api_roles/UpdateJamfApiRoleByID/UpdateJamfApiRoleByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/UpdateJamfApiRoleByID/UpdateJamfApiRoleByID.go
+++ b/examples/jamf_api_roles/UpdateJamfApiRoleByID/UpdateJamfApiRoleByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/UpdateJamfApiRoleByName/UpdateJamfApiRoleByName.go
+++ b/examples/jamf_api_roles/UpdateJamfApiRoleByName/UpdateJamfApiRoleByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_api_roles/UpdateJamfApiRoleByName/UpdateJamfApiRoleByName.go
+++ b/examples/jamf_api_roles/UpdateJamfApiRoleByName/UpdateJamfApiRoleByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_pro_version/GetJamfProVersion/GetJamfProVersion.go
+++ b/examples/jamf_pro_version/GetJamfProVersion/GetJamfProVersion.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/jamf_pro_version/GetJamfProVersion/GetJamfProVersion.go
+++ b/examples/jamf_pro_version/GetJamfProVersion/GetJamfProVersion.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/CreateMacOSConfigurationProfile/CreateMacOSConfigurationProfile.go
+++ b/examples/macos_configuration_profiles/CreateMacOSConfigurationProfile/CreateMacOSConfigurationProfile.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/CreateMacOSConfigurationProfile/CreateMacOSConfigurationProfile.go
+++ b/examples/macos_configuration_profiles/CreateMacOSConfigurationProfile/CreateMacOSConfigurationProfile.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/CreateMacOSConfigurationProfileWithFileUpload/CreateMacOSConfigurationProfileWithFileUpload.go
+++ b/examples/macos_configuration_profiles/CreateMacOSConfigurationProfileWithFileUpload/CreateMacOSConfigurationProfileWithFileUpload.go
@@ -42,14 +42,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/CreateMacOSConfigurationProfileWithFileUpload/CreateMacOSConfigurationProfileWithFileUpload.go
+++ b/examples/macos_configuration_profiles/CreateMacOSConfigurationProfileWithFileUpload/CreateMacOSConfigurationProfileWithFileUpload.go
@@ -42,14 +42,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByID/DeleteMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByID/DeleteMacOSConfigurationProfileByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByID/DeleteMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByID/DeleteMacOSConfigurationProfileByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByName/DeleteMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByName/DeleteMacOSConfigurationProfileByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByName/DeleteMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/DeleteMacOSConfigurationProfileByName/DeleteMacOSConfigurationProfileByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/ExportAllMacOSConfigurationProfilesToFiles/ExportAllMacOSConfigurationProfilesToFiles.go
+++ b/examples/macos_configuration_profiles/ExportAllMacOSConfigurationProfilesToFiles/ExportAllMacOSConfigurationProfilesToFiles.go
@@ -42,14 +42,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/ExportAllMacOSConfigurationProfilesToFiles/ExportAllMacOSConfigurationProfilesToFiles.go
+++ b/examples/macos_configuration_profiles/ExportAllMacOSConfigurationProfilesToFiles/ExportAllMacOSConfigurationProfilesToFiles.go
@@ -42,14 +42,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByID/GetMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByID/GetMacOSConfigurationProfileByID.go
@@ -29,14 +29,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByID/GetMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByID/GetMacOSConfigurationProfileByID.go
@@ -29,14 +29,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByName/GetMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByName/GetMacOSConfigurationProfileByName.go
@@ -29,14 +29,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByName/GetMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileByName/GetMacOSConfigurationProfileByName.go
@@ -29,14 +29,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileNameByID/GetMacOSConfigurationProfileNameByID.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileNameByID/GetMacOSConfigurationProfileNameByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfileNameByID/GetMacOSConfigurationProfileNameByID.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfileNameByID/GetMacOSConfigurationProfileNameByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfiles/GetMacOSConfigurationProfiles.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfiles/GetMacOSConfigurationProfiles.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/GetMacOSConfigurationProfiles/GetMacOSConfigurationProfiles.go
+++ b/examples/macos_configuration_profiles/GetMacOSConfigurationProfiles/GetMacOSConfigurationProfiles.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByID/UpdateMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByID/UpdateMacOSConfigurationProfileByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByID/UpdateMacOSConfigurationProfileByID.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByID/UpdateMacOSConfigurationProfileByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByIDWithFileUpload/UpdateMacOSConfigurationProfileByIDWithFileUpload.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByIDWithFileUpload/UpdateMacOSConfigurationProfileByIDWithFileUpload.go
@@ -34,14 +34,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByIDWithFileUpload/UpdateMacOSConfigurationProfileByIDWithFileUpload.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByIDWithFileUpload/UpdateMacOSConfigurationProfileByIDWithFileUpload.go
@@ -34,14 +34,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByName/UpdateMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByName/UpdateMacOSConfigurationProfileByName.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByName/UpdateMacOSConfigurationProfileByName.go
+++ b/examples/macos_configuration_profiles/UpdateMacOSConfigurationProfileByName/UpdateMacOSConfigurationProfileByName.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/CreateScript/CreateScript.go
+++ b/examples/scripts/CreateScript/CreateScript.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/CreateScript/CreateScript.go
+++ b/examples/scripts/CreateScript/CreateScript.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/CreateScriptWithFileUpload/CreateScriptWithFileUpload.go
+++ b/examples/scripts/CreateScriptWithFileUpload/CreateScriptWithFileUpload.go
@@ -30,14 +30,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/CreateScriptWithFileUpload/CreateScriptWithFileUpload.go
+++ b/examples/scripts/CreateScriptWithFileUpload/CreateScriptWithFileUpload.go
@@ -30,14 +30,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/DeleteScriptByID/DeleteScriptByID.go
+++ b/examples/scripts/DeleteScriptByID/DeleteScriptByID.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/DeleteScriptByID/DeleteScriptByID.go
+++ b/examples/scripts/DeleteScriptByID/DeleteScriptByID.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/DeleteScriptByName/DeleteScriptByName.go
+++ b/examples/scripts/DeleteScriptByName/DeleteScriptByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/DeleteScriptByName/DeleteScriptByName.go
+++ b/examples/scripts/DeleteScriptByName/DeleteScriptByName.go
@@ -28,14 +28,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScripts/GetScripts.go
+++ b/examples/scripts/GetScripts/GetScripts.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScripts/GetScripts.go
+++ b/examples/scripts/GetScripts/GetScripts.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScriptsByID/GetScriptsByID.go
+++ b/examples/scripts/GetScriptsByID/GetScriptsByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScriptsByID/GetScriptsByID.go
+++ b/examples/scripts/GetScriptsByID/GetScriptsByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScriptsByName/GetScriptsByName.go
+++ b/examples/scripts/GetScriptsByName/GetScriptsByName.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/GetScriptsByName/GetScriptsByName.go
+++ b/examples/scripts/GetScriptsByName/GetScriptsByName.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByID/UpdateScriptByID.go
+++ b/examples/scripts/UpdateScriptByID/UpdateScriptByID.go
@@ -28,14 +28,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByID/UpdateScriptByID.go
+++ b/examples/scripts/UpdateScriptByID/UpdateScriptByID.go
@@ -4,16 +4,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -28,14 +20,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByIDWithFile/UpdateScriptByIDWithFile.go
+++ b/examples/scripts/UpdateScriptByIDWithFile/UpdateScriptByIDWithFile.go
@@ -31,14 +31,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByIDWithFile/UpdateScriptByIDWithFile.go
+++ b/examples/scripts/UpdateScriptByIDWithFile/UpdateScriptByIDWithFile.go
@@ -31,14 +31,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByName/UpdateScriptByName.go
+++ b/examples/scripts/UpdateScriptByName/UpdateScriptByName.go
@@ -31,14 +31,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByName/UpdateScriptByName.go
+++ b/examples/scripts/UpdateScriptByName/UpdateScriptByName.go
@@ -31,14 +31,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByNameWithFileUpload/UpdateScriptByNameWithFileUpload.go
+++ b/examples/scripts/UpdateScriptByNameWithFileUpload/UpdateScriptByNameWithFileUpload.go
@@ -30,14 +30,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/scripts/UpdateScriptByNameWithFileUpload/UpdateScriptByNameWithFileUpload.go
+++ b/examples/scripts/UpdateScriptByNameWithFileUpload/UpdateScriptByNameWithFileUpload.go
@@ -30,14 +30,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/sso_failover/GetSSOFailoverURL/GetSSOFailoverURL.go
+++ b/examples/sso_failover/GetSSOFailoverURL/GetSSOFailoverURL.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instance

--- a/examples/sso_failover/GetSSOFailoverURL/GetSSOFailoverURL.go
+++ b/examples/sso_failover/GetSSOFailoverURL/GetSSOFailoverURL.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instance

--- a/examples/sso_failover/UpdateSSOFailoverURL/UpdateSSOFailoverURL.go
+++ b/examples/sso_failover/UpdateSSOFailoverURL/UpdateSSOFailoverURL.go
@@ -3,16 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
-)
-
-const (
-	concurrentRequests           = 10 // Number of simultaneous requests.
-	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
-	defaultTokenLifespan         = 30 * time.Minute
-	defaultBufferPeriod          = 5 * time.Minute
 )
 
 func main() {
@@ -27,14 +19,11 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:             authConfig.InstanceName,
-		DebugMode:                true,
-		Logger:                   jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
-		TokenLifespan:            defaultTokenLifespan,
-		TokenRefreshBufferPeriod: defaultBufferPeriod,
-		ClientID:                 authConfig.ClientID,
-		ClientSecret:             authConfig.ClientSecret,
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/examples/sso_failover/UpdateSSOFailoverURL/UpdateSSOFailoverURL.go
+++ b/examples/sso_failover/UpdateSSOFailoverURL/UpdateSSOFailoverURL.go
@@ -27,14 +27,14 @@ func main() {
 
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
-		InstanceName:          authConfig.InstanceName,
-		DebugMode:             true,
-		Logger:                jamfpro.NewDefaultLogger(),
-		MaxConcurrentRequests: maxConcurrentRequestsAllowed,
-		TokenLifespan:         defaultTokenLifespan,
-		BufferPeriod:          defaultBufferPeriod,
-		ClientID:              authConfig.ClientID,
-		ClientSecret:          authConfig.ClientSecret,
+		InstanceName:             authConfig.InstanceName,
+		DebugMode:                true,
+		Logger:                   jamfpro.NewDefaultLogger(),
+		MaxConcurrentRequests:    maxConcurrentRequestsAllowed,
+		TokenLifespan:            defaultTokenLifespan,
+		TokenRefreshBufferPeriod: defaultBufferPeriod,
+		ClientID:                 authConfig.ClientID,
+		ClientSecret:             authConfig.ClientSecret,
 	}
 
 	// Create a new jamfpro client instanceclient,

--- a/sdk/http_client/http_client.go
+++ b/sdk/http_client/http_client.go
@@ -23,8 +23,8 @@ type Client struct {
 	InstanceName               string
 	authMethod                 string // Specifies the authentication method: "bearer" or "oauth"
 	Token                      string
-	oAuthCredentials           OAuthCredentials           // ClientID / Client Secret
-	bearerTokenAuthCredentials BearerTokenAuthCredentials // Username and Password for Basic Authentication
+	OAuthCredentials           OAuthCredentials           // ClientID / Client Secret
+	BearerTokenAuthCredentials BearerTokenAuthCredentials // Username and Password for Basic Authentication
 	Expiry                     time.Time
 	httpClient                 *http.Client
 	tokenLock                  sync.Mutex

--- a/sdk/http_client/http_client.go
+++ b/sdk/http_client/http_client.go
@@ -42,7 +42,7 @@ type Config struct {
 	Logger                    Logger
 	MaxConcurrentRequests     int
 	TokenLifespan             time.Duration
-	BufferPeriod              time.Duration
+	TokenRefreshBufferPeriod  time.Duration
 	TotalRetryDuration        time.Duration
 }
 
@@ -93,8 +93,8 @@ func NewClient(instanceName string, config Config, logger Logger, options ...Cli
 	if config.TokenLifespan == 0 {
 		config.TokenLifespan = 30 * time.Minute
 	}
-	if config.BufferPeriod == 0 {
-		config.BufferPeriod = 5 * time.Minute
+	if config.TokenRefreshBufferPeriod == 0 {
+		config.TokenRefreshBufferPeriod = 5 * time.Minute
 	}
 	if config.TotalRetryDuration == 0 {
 		config.TotalRetryDuration = 60 * time.Second
@@ -123,7 +123,7 @@ func NewClient(instanceName string, config Config, logger Logger, options ...Cli
 			"InstanceName", client.InstanceName,
 			"Timeout", client.httpClient.Timeout,
 			"TokenLifespan", client.config.TokenLifespan,
-			"BufferPeriod", client.config.BufferPeriod,
+			"TokenRefreshBufferPeriod", client.config.TokenRefreshBufferPeriod,
 			"TotalRetryDuration", client.config.TotalRetryDuration,
 			"MaxRetryAttempts", client.config.MaxRetryAttempts,
 			"MaxConcurrentRequests", client.config.MaxConcurrentRequests,

--- a/sdk/http_client/http_client_bearer_token_auth.go
+++ b/sdk/http_client/http_client_bearer_token_auth.go
@@ -20,7 +20,7 @@ type BearerTokenAuthCredentials struct {
 // for the client instance. These credentials are used for obtaining and refreshing
 // bearer tokens for authentication.
 func (c *Client) SetBearerTokenAuthCredentials(credentials BearerTokenAuthCredentials) {
-	c.bearerTokenAuthCredentials = credentials
+	c.BearerTokenAuthCredentials = credentials
 }
 
 // ObtainToken fetches and sets an authentication token using the stored basic authentication credentials.
@@ -28,7 +28,7 @@ func (c *Client) ObtainToken() error {
 	authenticationEndpoint := c.constructAPIAuthEndpoint(BearerTokenEndpoint)
 
 	if c.config.DebugMode {
-		c.logger.Debug("Attempting to obtain token for user", "Username", c.bearerTokenAuthCredentials.Username)
+		c.logger.Debug("Attempting to obtain token for user", "Username", c.BearerTokenAuthCredentials.Username)
 	}
 
 	req, err := http.NewRequest("POST", authenticationEndpoint, nil)
@@ -36,7 +36,7 @@ func (c *Client) ObtainToken() error {
 		c.logger.Error("Failed to create new request for token", "Error", err)
 		return err
 	}
-	req.SetBasicAuth(c.bearerTokenAuthCredentials.Username, c.bearerTokenAuthCredentials.Password)
+	req.SetBasicAuth(c.BearerTokenAuthCredentials.Username, c.BearerTokenAuthCredentials.Password)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/sdk/http_client/http_client_oauth.go
+++ b/sdk/http_client/http_client_oauth.go
@@ -43,7 +43,7 @@ type OAuthCredentials struct {
 // for the client instance. These credentials are used for obtaining and refreshing
 // OAuth tokens for authentication.
 func (c *Client) SetOAuthCredentials(credentials OAuthCredentials) {
-	c.oAuthCredentials = credentials
+	c.OAuthCredentials = credentials
 }
 
 // ObtainOAuthToken fetches an OAuth access token using the provided OAuthCredentials (Client ID and Client Secret).

--- a/sdk/http_client/http_helpers.go
+++ b/sdk/http_client/http_helpers.go
@@ -34,7 +34,7 @@ func (c *Client) SetAuthenticationCredentials(creds map[string]string) {
 	// Check for OAuth credentials
 	if clientID, ok := creds["clientID"]; ok {
 		if clientSecret, ok := creds["clientSecret"]; ok {
-			c.oAuthCredentials = OAuthCredentials{
+			c.OAuthCredentials = OAuthCredentials{
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
 			}
@@ -46,7 +46,7 @@ func (c *Client) SetAuthenticationCredentials(creds map[string]string) {
 	// Check for Bearer Token credentials
 	if username, ok := creds["username"]; ok {
 		if password, ok := creds["password"]; ok {
-			c.bearerTokenAuthCredentials = BearerTokenAuthCredentials{
+			c.BearerTokenAuthCredentials = BearerTokenAuthCredentials{
 				Username: username,
 				Password: password,
 			}
@@ -59,11 +59,11 @@ func (c *Client) SetAuthenticationCredentials(creds map[string]string) {
 // GetOAuthCredentials retrieves the current OAuth credentials (Client ID and Client Secret)
 // set for the client instance. Used for test cases.
 func (c *Client) GetOAuthCredentials() OAuthCredentials {
-	return c.oAuthCredentials
+	return c.OAuthCredentials
 }
 
 // GetBearerAuthCredentials retrieves the current bearer auth credentials (Username and Password)
 // set for the client instance. Used for test cases.
 func (c *Client) GetBearerAuthCredentials() BearerTokenAuthCredentials {
-	return c.bearerTokenAuthCredentials
+	return c.BearerTokenAuthCredentials
 }

--- a/sdk/http_client/http_token_management.go
+++ b/sdk/http_client/http_token_management.go
@@ -17,13 +17,13 @@ func (c *Client) ValidAuthTokenCheck() bool {
 
 	// If token doesn't exist
 	if c.Token == "" {
-		if c.bearerTokenAuthCredentials.Username != "" && c.bearerTokenAuthCredentials.Password != "" {
+		if c.BearerTokenAuthCredentials.Username != "" && c.BearerTokenAuthCredentials.Password != "" {
 			err := c.ObtainToken()
 			if err != nil {
 				return false
 			}
-		} else if c.oAuthCredentials.ClientID != "" && c.oAuthCredentials.ClientSecret != "" {
-			err := c.ObtainOAuthToken(c.oAuthCredentials)
+		} else if c.OAuthCredentials.ClientID != "" && c.OAuthCredentials.ClientSecret != "" {
+			err := c.ObtainOAuthToken(c.OAuthCredentials)
 			if err != nil {
 				return false
 			}
@@ -40,9 +40,9 @@ func (c *Client) ValidAuthTokenCheck() bool {
 		}
 
 		var err error
-		if c.bearerTokenAuthCredentials.Username != "" && c.bearerTokenAuthCredentials.Password != "" {
+		if c.BearerTokenAuthCredentials.Username != "" && c.BearerTokenAuthCredentials.Password != "" {
 			err = c.RefreshToken()
-		} else if c.oAuthCredentials.ClientID != "" && c.oAuthCredentials.ClientSecret != "" {
+		} else if c.OAuthCredentials.ClientID != "" && c.OAuthCredentials.ClientSecret != "" {
 			err = c.RefreshOAuthToken()
 		} else {
 			c.logger.Error("Unknown auth method", "AuthMethod", c.authMethod)

--- a/sdk/http_client/http_token_management.go
+++ b/sdk/http_client/http_token_management.go
@@ -34,7 +34,7 @@ func (c *Client) ValidAuthTokenCheck() bool {
 	}
 
 	// If token exists and is close to expiry or already expired
-	if time.Until(c.Expiry) < c.config.BufferPeriod {
+	if time.Until(c.Expiry) < c.config.TokenRefreshBufferPeriod {
 		if c.config.DebugMode {
 			c.logger.Debug("Token is not valid or is close to expiry", "Expiry", c.Expiry)
 		}

--- a/sdk/jamfpro/shared_api_client.go
+++ b/sdk/jamfpro/shared_api_client.go
@@ -51,7 +51,7 @@ func NewClient(config Config) (*Client, error) {
 	if config.TokenRefreshBufferPeriod == 0 {
 		config.TokenRefreshBufferPeriod = defaultBufferPeriod
 	}
-
+	// Initialise http client
 	httpConfig := http_client.Config{
 		DebugMode:                config.DebugMode,
 		Logger:                   config.Logger,
@@ -80,7 +80,7 @@ func NewClient(config Config) (*Client, error) {
 	if client.HTTP.GetOAuthCredentials().ClientID == "" || client.HTTP.GetOAuthCredentials().ClientSecret == "" {
 		return nil, fmt.Errorf("OAuth credentials (ClientID and ClientSecret) must be provided")
 	}
-
+	// return complete initialised client with auth credentials added.
 	return client, nil
 }
 

--- a/sdk/jamfpro/shared_api_client.go
+++ b/sdk/jamfpro/shared_api_client.go
@@ -17,6 +17,13 @@ import (
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
 )
 
+const (
+	concurrentRequests           = 10 // Number of simultaneous requests.
+	maxConcurrentRequestsAllowed = 5  // Maximum allowed concurrent requests.
+	defaultTokenLifespan         = 30 * time.Minute
+	defaultBufferPeriod          = 5 * time.Minute
+)
+
 type Client struct {
 	HTTP *http_client.Client
 }
@@ -33,6 +40,18 @@ type Config struct {
 }
 
 func NewClient(config Config) (*Client, error) {
+
+	// If not provided, use the default values from constants
+	if config.MaxConcurrentRequests == 0 {
+		config.MaxConcurrentRequests = maxConcurrentRequestsAllowed
+	}
+	if config.TokenLifespan == 0 {
+		config.TokenLifespan = defaultTokenLifespan
+	}
+	if config.TokenRefreshBufferPeriod == 0 {
+		config.TokenRefreshBufferPeriod = defaultBufferPeriod
+	}
+
 	httpConfig := http_client.Config{
 		DebugMode:                config.DebugMode,
 		Logger:                   config.Logger,

--- a/sdk/jamfpro/shared_api_client.go
+++ b/sdk/jamfpro/shared_api_client.go
@@ -22,23 +22,23 @@ type Client struct {
 }
 
 type Config struct {
-	InstanceName          string
-	DebugMode             bool
-	Logger                http_client.Logger
-	MaxConcurrentRequests int
-	TokenLifespan         time.Duration
-	BufferPeriod          time.Duration
-	ClientID              string
-	ClientSecret          string
+	InstanceName             string
+	DebugMode                bool
+	Logger                   http_client.Logger
+	MaxConcurrentRequests    int
+	TokenLifespan            time.Duration
+	TokenRefreshBufferPeriod time.Duration
+	ClientID                 string
+	ClientSecret             string
 }
 
 func NewClient(config Config) (*Client, error) {
 	httpConfig := http_client.Config{
-		DebugMode:             config.DebugMode,
-		Logger:                config.Logger,
-		MaxConcurrentRequests: config.MaxConcurrentRequests,
-		TokenLifespan:         config.TokenLifespan,
-		BufferPeriod:          config.BufferPeriod,
+		DebugMode:                config.DebugMode,
+		Logger:                   config.Logger,
+		MaxConcurrentRequests:    config.MaxConcurrentRequests,
+		TokenLifespan:            config.TokenLifespan,
+		TokenRefreshBufferPeriod: config.TokenRefreshBufferPeriod,
 	}
 
 	httpCli, err := http_client.NewClient(config.InstanceName, httpConfig, nil)

--- a/sdk/jamfpro/shared_api_client_test.go
+++ b/sdk/jamfpro/shared_api_client_test.go
@@ -11,14 +11,14 @@ import (
 func TestOAuthCredentialsSetting(t *testing.T) {
 	// Mock config for testing
 	config := Config{
-		InstanceName:          "testInstance",
-		DebugMode:             false,
-		Logger:                http_client.NewDefaultLogger(),
-		MaxConcurrentRequests: 5,
-		TokenLifespan:         30 * time.Minute,
-		BufferPeriod:          5 * time.Minute,
-		ClientID:              "mockClientID",
-		ClientSecret:          "mockClientSecret",
+		InstanceName:             "testInstance",
+		DebugMode:                false,
+		Logger:                   http_client.NewDefaultLogger(),
+		MaxConcurrentRequests:    5,
+		TokenLifespan:            30 * time.Minute,
+		TokenRefreshBufferPeriod: 5 * time.Minute,
+		ClientID:                 "mockClientID",
+		ClientSecret:             "mockClientSecret",
 	}
 
 	logger.Info("Initializing client with mock configuration...")


### PR DESCRIPTION
renamed BufferPeriod struct to TokenRefreshBufferPeriod for clarity in http_client package

moved constants for http_client initialisation into shared_api_client.go. removed const's from examples to simplify http client initialisation and to make the examples more straight forward.
