### PR TITLE
Added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 # Testing with local auth
 *auth.json
+
+# macOS File System
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ DELETE `/JSSResource/computergroups/name/{name}` - DeleteComputerGroupByName deletes a computer group by its name.
 
 
+### Jamf Pro Classic API - Computer Extension Attributes
+
+- [ ] ✅ GET `/JSSResource/computerextensionattributes` - GetComputerExtensionAttributes gets a list of all computer extension attributes.
+- [ ] ✅ GET `/JSSResource/computerextensionattributes/id/{id}` - GetComputerExtensionAttributeByID retrieves a computer extension attribute by its ID.
+- [ ] ✅ GET `/JSSResource/computerextensionattributes/name/{name}` - GetComputerExtensionAttributeByName retrieves a computer extension attribute by its name.
+- [ ] ✅ POST `/JSSResource/computerextensionattributes/id/0` - CreateComputerExtensionAttribute creates a new computer extension attribute.
+- [ ] ✅ PUT `/JSSResource/computerextensionattributes/id/{id}` - UpdateComputerExtensionAttributeByID updates an existing computer extension attribute by its ID.
+- [ ] ✅ PUT `/JSSResource/computerextensionattributes/name/{name}` - UpdateComputerExtensionAttributeByName updates a computer extension attribute by its name.
+- [ ] ✅ DELETE `/JSSResource/computerextensionattributes/id/{id}` - DeleteComputerExtensionAttributeByID deletes a computer extension attribute by its ID.
+- [ ] ⚠️ DELETE (Complex Operation) - `DeleteComputerExtensionAttributeByNameByID` deletes a computer extension attribute by its name (involves fetching ID by name first). 
+
+
 ### Departments - /JSSResource/departments
 
 - [ ] ✅ GET `/JSSResource/departments` - GetDepartments retrieves all departments

--- a/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
+++ b/examples/allowed_file_extensions/GetAllowedFileExtensionByID/GetAllowedFileExtensionByID.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	// Define the ID for the file extension you want to fetch
-	fileExtensionID := 1 // Replace with the desired ID
+	fileExtensionID := 142 // Replace with the desired ID
 
 	// Call GetAllowedFileExtensionByID function
 	allowedExtension, err := client.GetAllowedFileExtensionByID(fileExtensionID)

--- a/examples/computer_extension_attributes/CreateComputerExtensionAttribute/CreateComputerExtensionAttribute.go
+++ b/examples/computer_extension_attributes/CreateComputerExtensionAttribute/CreateComputerExtensionAttribute.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the new computer extension attribute
+	attribute := &jamfpro.ComputerExtensionAttributeResponse{
+		Name:             "Battery Cycle Count",
+		Description:      "Number of charge cycles logged on the current battery",
+		DataType:         "String",
+		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Text Field"},
+		InventoryDisplay: "General",
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	// Call CreateComputerExtensionAttribute function
+	createdAttribute, err := client.CreateComputerExtensionAttribute(attribute)
+	if err != nil {
+		log.Fatalf("Error creating Computer Extension Attribute: %v", err)
+	}
+
+	// Pretty print the created attribute in XML
+	createdAttributeXML, err := xml.MarshalIndent(createdAttribute, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Created Computer Extension Attribute:\n", string(createdAttributeXML))
+}

--- a/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithPopUpMenu/CreateComputerExtensionAttributeWithPopUpMenu.go
+++ b/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithPopUpMenu/CreateComputerExtensionAttributeWithPopUpMenu.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the choices for the popup menu
+	choices := []string{"Choice 1", "Choice 2", "Choice 3"}
+
+	// Define the new computer extension attribute
+	attribute := &jamfpro.ComputerExtensionAttributeResponse{
+		Name:             "Pop Up Menu Test",
+		Description:      "Pop Up Menu Test",
+		DataType:         "String",                                                                           // String / Integer / Date (YYYY-MM-DD hh:mm:ss)
+		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Pop Up Menu", Choices: choices}, //  Text Field / Pop Up Menu / Script
+		InventoryDisplay: "General",                                                                          // General / Hardware / Operating System / User and Location / Purchasing / Extension Attribute
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	// Call CreateComputerExtensionAttribute function
+	createdAttribute, err := client.CreateComputerExtensionAttribute(attribute)
+	if err != nil {
+		log.Fatalf("Error creating Computer Extension Attribute: %v", err)
+	}
+
+	// Pretty print the created attribute in XML
+	createdAttributeXML, err := xml.MarshalIndent(createdAttribute, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Created Computer Extension Attribute:\n", string(createdAttributeXML))
+}

--- a/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithScript/CreateComputerExtensionAttributeWithScript.go
+++ b/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithScript/CreateComputerExtensionAttributeWithScript.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func loadScriptFromFile(filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Load the script from a file
+	scriptPath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/examples/support_files/computer_extensioin_attribute.sh"
+	scriptContent, err := loadScriptFromFile(scriptPath)
+	if err != nil {
+		log.Fatalf("Failed to load script from file: %v", err)
+	}
+
+	// Define the new computer extension attribute
+	attribute := &jamfpro.ComputerExtensionAttributeResponse{
+		Name:        "Computer Extension Attribute Script Test",
+		Description: "Computer Extension Attribute SCript Test",
+		DataType:    "String", // String / Integer / Date (YYYY-MM-DD hh:mm:ss)
+		InputType: jamfpro.ComputerExtensionAttributeInputType{
+			Type:     "Script",
+			Script:   scriptContent,
+			Platform: "Mac", // Set this to the desired platform: "Mac" or "Windows".
+		},
+		InventoryDisplay: "General", // General / Hardware / Operating System / User and Location / Purchasing / Extension Attribute
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	// Call CreateComputerExtensionAttribute function
+	createdAttribute, err := client.CreateComputerExtensionAttribute(attribute)
+	if err != nil {
+		log.Fatalf("Error creating Computer Extension Attribute: %v", err)
+	}
+
+	// Pretty print the created attribute in XML
+	createdAttributeXML, err := xml.MarshalIndent(createdAttribute, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Created Computer Extension Attribute:\n", string(createdAttributeXML))
+}

--- a/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithTextField/CreateComputerExtensionAttributeWithTextField.go
+++ b/examples/computer_extension_attributes/CreateComputerExtensionAttributeWithTextField/CreateComputerExtensionAttributeWithTextField.go
@@ -37,9 +37,9 @@ func main() {
 	attribute := &jamfpro.ComputerExtensionAttributeResponse{
 		Name:             "Battery Cycle Count",
 		Description:      "Number of charge cycles logged on the current battery",
-		DataType:         "String",
-		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Text Field"},
-		InventoryDisplay: "General",
+		DataType:         "String",                                                        // String / Integer / Date (YYYY-MM-DD hh:mm:ss)
+		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Text Field"}, //  Text Field / Pop Up Menu / Script
+		InventoryDisplay: "General",                                                       // General / Hardware / Operating System / User and Location / Purchasing / Extension Attribute
 		ReconDisplay:     "Extension Attributes",
 	}
 

--- a/examples/computer_extension_attributes/DeleteComputerExtensionAttributeByID/DeleteComputerExtensionAttributeByID.go
+++ b/examples/computer_extension_attributes/DeleteComputerExtensionAttributeByID/DeleteComputerExtensionAttributeByID.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+const AttributeIDToDelete = 123 // Replace 123 with the ID of the attribute you wish to delete
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Deleting the attribute with specified ID
+	err = client.DeleteComputerExtensionAttributeByID(AttributeIDToDelete)
+	if err != nil {
+		log.Fatalf("Error deleting Computer Extension Attribute by ID: %v", err)
+	}
+
+	fmt.Printf("Successfully deleted Computer Extension Attribute with ID: %d\n", AttributeIDToDelete)
+}

--- a/examples/computer_extension_attributes/DeleteComputerExtensionAttributeByNameByID/DeleteComputerExtensionAttributeByNameByID.go
+++ b/examples/computer_extension_attributes/DeleteComputerExtensionAttributeByNameByID/DeleteComputerExtensionAttributeByNameByID.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+const (
+	configFilePath = "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+	attributeName  = "Battery Cycle Count" // replace this with the name of the attribute you want to delete
+)
+
+func main() {
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Call DeleteComputerExtensionAttributeByName function
+	err = client.DeleteComputerExtensionAttributeByNameByID(attributeName)
+	if err != nil {
+		log.Fatalf("Error deleting Computer Extension Attribute by name: %v", err)
+	}
+
+	fmt.Println("Successfully deleted Computer Extension Attribute:", attributeName)
+}

--- a/examples/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
+++ b/examples/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+// path to export the scripts
+const exportPath = "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/examples/support_files/export"
+
+func sanitizeFileName(fileName string) string {
+	// Remove any characters that are not letters, numbers, hyphens, or underscores
+	reg := regexp.MustCompile("[^a-zA-Z0-9-_]+")
+	sanitized := reg.ReplaceAllString(fileName, "_")
+
+	return strings.Trim(sanitized, "_")
+}
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Get a list of all computer extension attributes
+	attributesList, err := client.GetComputerExtensionAttributes()
+	if err != nil {
+		log.Fatalf("Failed to fetch Computer Extension Attributes: %v", err)
+	}
+
+	for _, attributeItem := range attributesList.Results {
+		// Get details for each attribute
+		attribute, err := client.GetComputerExtensionAttributeByID(attributeItem.ID)
+		if err != nil {
+			log.Printf("Failed to fetch details for attribute %s (ID: %d): %v", attributeItem.Name, attributeItem.ID, err)
+			continue
+		}
+
+		// Check if the type is "Script"
+		if attribute.InputType.Type == "Script" {
+			// Sanitize the attribute name to be used as a filename
+			sanitizedFileName := sanitizeFileName(attribute.Name)
+
+			// Export the script content
+			scriptFileName := filepath.Join(exportPath, sanitizedFileName+".sh")
+
+			err = os.WriteFile(scriptFileName, []byte(attribute.InputType.Script), 0644)
+			if err != nil {
+				log.Printf("Failed to write script for attribute '%s' to file '%s': %v", attribute.Name, scriptFileName, err)
+				continue
+			}
+			fmt.Printf("Exported script for attribute '%s' to file '%s'\n", attribute.Name, scriptFileName)
+		}
+	}
+}

--- a/examples/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
+++ b/examples/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
@@ -35,7 +35,7 @@ func main() {
 	// Configuration for the jamfpro
 	config := jamfpro.Config{
 		InstanceName: authConfig.InstanceName,
-		DebugMode:    true,
+		DebugMode:    false,
 		Logger:       jamfpro.NewDefaultLogger(),
 		ClientID:     authConfig.ClientID,
 		ClientSecret: authConfig.ClientSecret,
@@ -47,6 +47,14 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
+	// Ensure that the export directory exists
+	if _, err := os.Stat(exportPath); os.IsNotExist(err) {
+		err = os.MkdirAll(exportPath, 0755)
+		if err != nil {
+			log.Fatalf("Failed to create export directory: %v", err)
+		}
+	}
+
 	// Get a list of all computer extension attributes
 	attributesList, err := client.GetComputerExtensionAttributes()
 	if err != nil {
@@ -54,6 +62,9 @@ func main() {
 	}
 
 	for _, attributeItem := range attributesList.Results {
+		// Log to indicate which extension attribute is being processed
+		log.Printf("Processing extension attribute '%s' (ID: %d)\n", attributeItem.Name, attributeItem.ID)
+
 		// Get details for each attribute
 		attribute, err := client.GetComputerExtensionAttributeByID(attributeItem.ID)
 		if err != nil {
@@ -61,20 +72,47 @@ func main() {
 			continue
 		}
 
+		// Log the type of the attribute for debugging
+		log.Printf("Attribute '%s' is of type '%s'\n", attribute.Name, attribute.InputType.Type)
+
 		// Check if the type is "Script"
-		if attribute.InputType.Type == "Script" {
+		if strings.ToLower(attribute.InputType.Type) == "script" {
 			// Sanitize the attribute name to be used as a filename
 			sanitizedFileName := sanitizeFileName(attribute.Name)
 
 			// Export the script content
 			scriptFileName := filepath.Join(exportPath, sanitizedFileName+".sh")
 
-			err = os.WriteFile(scriptFileName, []byte(attribute.InputType.Script), 0644)
+			// Log to indicate where the script intends to export the extension attribute
+			log.Printf("Exporting computer extension attribute '%s' to: %s", attribute.Name, scriptFileName)
+
+			// Check if file already exists
+			if _, err := os.Stat(scriptFileName); err == nil {
+				log.Printf("File %s already exists!", scriptFileName)
+			} else if !os.IsNotExist(err) {
+				log.Printf("Error checking if file exists: %v", err)
+			}
+
+			// Use os.Create to create or truncate the file for writing
+			file, err := os.Create(scriptFileName)
+			if err != nil {
+				log.Printf("Failed to create file for attribute '%s': %v", attribute.Name, err)
+				continue
+			}
+			defer file.Close()
+
+			_, err = file.WriteString(attribute.InputType.Script)
 			if err != nil {
 				log.Printf("Failed to write script for attribute '%s' to file '%s': %v", attribute.Name, scriptFileName, err)
 				continue
 			}
 			fmt.Printf("Exported script for attribute '%s' to file '%s'\n", attribute.Name, scriptFileName)
+		} else {
+			log.Printf("Attribute '%s' is not of type 'Script', skipping export.\n", attribute.Name)
+		}
+
+		if err != nil {
+			log.Printf("Error encountered: %v", err)
 		}
 	}
 }

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributeByID/GetComputerExtensionAttributeByID.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributeByID/GetComputerExtensionAttributeByID.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	// Provide the ID of the computer extension attribute you want to fetch
-	attributeID := 14 // You can change this ID as required
+	attributeID := 11 // You can change this ID as required
 
 	// Call GetComputerExtensionAttributeByID function
 	attribute, err := client.GetComputerExtensionAttributeByID(attributeID)

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributeByID/GetComputerExtensionAttributeByID.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributeByID/GetComputerExtensionAttributeByID.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Provide the ID of the computer extension attribute you want to fetch
+	attributeID := 14 // You can change this ID as required
+
+	// Call GetComputerExtensionAttributeByID function
+	attribute, err := client.GetComputerExtensionAttributeByID(attributeID)
+	if err != nil {
+		log.Fatalf("Error fetching Computer Extension Attribute by ID: %v", err)
+	}
+
+	// Pretty print the attribute in XML
+	attributeXML, err := xml.MarshalIndent(attribute, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Fetched Computer Extension Attribute by ID:\n", string(attributeXML))
+}

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributeByName/GetComputerExtensionAttributeByName.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributeByName/GetComputerExtensionAttributeByName.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	// Provide the name of the computer extension attribute you want to fetch
-	attributeName := "Battery Cycle Count" // You can change this name as required
+	attributeName := "M365_Updates_Pending" // You can change this name as required
 
 	// Call GetComputerExtensionAttributeByName function
 	attribute, err := client.GetComputerExtensionAttributeByName(attributeName)

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributeByName/GetComputerExtensionAttributeByName.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributeByName/GetComputerExtensionAttributeByName.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Provide the name of the computer extension attribute you want to fetch
+	attributeName := "Battery Cycle Count" // You can change this name as required
+
+	// Call GetComputerExtensionAttributeByName function
+	attribute, err := client.GetComputerExtensionAttributeByName(attributeName)
+	if err != nil {
+		log.Fatalf("Error fetching Computer Extension Attribute by name: %v", err)
+	}
+
+	// Pretty print the attribute in XML
+	attributeXML, err := xml.MarshalIndent(attribute, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Fetched Computer Extension Attribute by name:\n", string(attributeXML))
+}

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Call GetComputerExtensionAttributes function
+	attributes, err := client.GetComputerExtensionAttributes()
+	if err != nil {
+		log.Fatalf("Error fetching Computer Extension Attributes: %v", err)
+	}
+
+	// Pretty print the attributes in XML
+	attributesXML, err := xml.MarshalIndent(attributes, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling Computer Extension Attributes data: %v", err)
+	}
+	fmt.Println("Fetched Computer Extension Attributes:\n", string(attributesXML))
+}

--- a/examples/computer_extension_attributes/UpdateComputerExtensionAttributeByID/UpdateComputerExtensionAttributeByID.go
+++ b/examples/computer_extension_attributes/UpdateComputerExtensionAttributeByID/UpdateComputerExtensionAttributeByID.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	attributeToUpdate := &jamfpro.ComputerExtensionAttributeResponse{
+		Name:             "Battery Cycle Count",
+		Description:      "Number of charge cycles logged on the current battery",
+		DataType:         "String",
+		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Text Field"},
+		InventoryDisplay: "General",
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	// Assuming you're updating the attribute with ID = 1
+	updatedAttribute, err := client.UpdateComputerExtensionAttributeByID(1, attributeToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating Computer Extension Attribute by ID: %v", err)
+	}
+
+	attributeXML, err := xml.MarshalIndent(updatedAttribute, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Updated Computer Extension Attribute by ID:\n", string(attributeXML))
+}

--- a/examples/computer_extension_attributes/UpdateComputerExtensionAttributeByName/UpdateComputerExtensionAttributeByName.go
+++ b/examples/computer_extension_attributes/UpdateComputerExtensionAttributeByName/UpdateComputerExtensionAttributeByName.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	attributeToUpdate := &jamfpro.ComputerExtensionAttributeResponse{
+		Name:             "Battery Cycle Count Updated", // Notice the "Updated" suffix for demonstration
+		Description:      "Number of charge cycles logged on the current battery",
+		DataType:         "String",
+		InputType:        jamfpro.ComputerExtensionAttributeInputType{Type: "Text Field"},
+		InventoryDisplay: "General",
+		ReconDisplay:     "Extension Attributes",
+	}
+
+	// Updating the attribute with name "Battery Cycle Count" to "Battery Cycle Count Updated"
+	updatedAttribute, err := client.UpdateComputerExtensionAttributeByName("Battery Cycle Count", attributeToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating Computer Extension Attribute by Name: %v", err)
+	}
+
+	attributeXML, err := xml.MarshalIndent(updatedAttribute, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated Computer Extension Attribute data: %v", err)
+	}
+	fmt.Println("Updated Computer Extension Attribute by Name:\n", string(attributeXML))
+}

--- a/examples/support_files/computer_extensioin_attribute.sh
+++ b/examples/support_files/computer_extensioin_attribute.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+########## variable-ing ##########
+
+
+
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+
+
+
+########## main process ##########
+
+
+
+# Report logged-in user.
+echo "<result>$loggedInUser</result>"
+
+
+
+exit 0

--- a/sdk/jamfpro/classicapi_computer_extension_attributes.go
+++ b/sdk/jamfpro/classicapi_computer_extension_attributes.go
@@ -1,0 +1,210 @@
+// classicapi_computer_extension_attributes.go
+// Jamf Pro Classic Api - Computer Extension Attributes
+// api reference: https://developer.jamf.com/jamf-pro/reference/computerextensionattributes
+// Classic API requires the structs to support an XML data structure.
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+const uriComputerExtensionAttributes = "/JSSResource/computerextensionattributes"
+
+// Structs for the computer extension attributes
+
+type ComputerExtensionAttributesListResponse struct {
+	Size    int                              `xml:"size"`
+	Results []ComputerExtensionAttributeItem `xml:"computer_extension_attribute"`
+}
+
+type ComputerExtensionAttributeItem struct {
+	ID      int    `xml:"id,omitempty"`
+	Name    string `xml:"name,omitempty"`
+	Enabled bool   `xml:"enabled,omitempty"`
+}
+
+type ComputerExtensionAttributeResponse struct {
+	ID               int                                 `xml:"id"`
+	Name             string                              `xml:"name"`
+	Enabled          bool                                `xml:"enabled,omitempty"`
+	Description      string                              `xml:"description,omitempty"`
+	DataType         string                              `xml:"data_type,omitempty"`
+	InputType        ComputerExtensionAttributeInputType `xml:"input_type"`
+	InventoryDisplay string                              `xml:"inventory_display,omitempty"`
+	ReconDisplay     string                              `xml:"recon_display,omitempty"`
+}
+
+type ComputerExtensionAttributeInputType struct {
+	Type     string   `xml:"type"`
+	Platform string   `xml:"platform,omitempty"`
+	Script   string   `xml:"script,omitempty"`
+	Choices  []string `xml:"popup_choices>choice,omitempty"`
+}
+
+// GetComputerExtensionAttributes gets a list of all computer extension attributes
+func (c *Client) GetComputerExtensionAttributes() (*ComputerExtensionAttributesListResponse, error) {
+	endpoint := uriComputerExtensionAttributes
+
+	var attributes ComputerExtensionAttributesListResponse
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &attributes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch all Computer Extension Attributes: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &attributes, nil
+}
+
+// GetComputerExtensionAttributeByID retrieves a computer extension attribute by its ID.
+func (c *Client) GetComputerExtensionAttributeByID(id int) (*ComputerExtensionAttributeResponse, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriComputerExtensionAttributes, id)
+
+	var attribute ComputerExtensionAttributeResponse
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &attribute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Computer Extension Attribute by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &attribute, nil
+}
+
+// GetComputerExtensionAttributeByName retrieves a computer extension attribute by its name.
+func (c *Client) GetComputerExtensionAttributeByName(name string) (*ComputerExtensionAttributeResponse, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriComputerExtensionAttributes, name)
+
+	var attribute ComputerExtensionAttributeResponse
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &attribute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Computer Extension Attribute by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &attribute, nil
+}
+
+// CreateComputerExtensionAttribute creates a new computer extension attribute.
+func (c *Client) CreateComputerExtensionAttribute(attribute *ComputerExtensionAttributeResponse) (*ComputerExtensionAttributeResponse, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriComputerExtensionAttributes) // Using ID 0 for creation as per the pattern
+
+	// Wrap the attribute request with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"computer_extension_attribute"`
+		*ComputerExtensionAttributeResponse
+	}{
+		ComputerExtensionAttributeResponse: attribute,
+	}
+
+	var createdAttribute ComputerExtensionAttributeResponse
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &createdAttribute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Computer Extension Attribute: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &createdAttribute, nil
+}
+
+// UpdateComputerExtensionAttributeByID updates an existing computer extension attribute by its ID.
+func (c *Client) UpdateComputerExtensionAttributeByID(id int, attribute *ComputerExtensionAttributeResponse) (*ComputerExtensionAttributeResponse, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriComputerExtensionAttributes, id)
+
+	// Wrap the attribute request with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"computer_extension_attribute"`
+		*ComputerExtensionAttributeResponse
+	}{
+		ComputerExtensionAttributeResponse: attribute,
+	}
+
+	var updatedAttribute ComputerExtensionAttributeResponse
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedAttribute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Computer Extension Attribute by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedAttribute, nil
+}
+
+// UpdateComputerExtensionAttributeByName updates a computer extension attribute by its name.
+func (c *Client) UpdateComputerExtensionAttributeByName(name string, attribute *ComputerExtensionAttributeResponse) (*ComputerExtensionAttributeResponse, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriComputerExtensionAttributes, name)
+
+	// Wrap the attribute request with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"computer_extension_attribute"`
+		*ComputerExtensionAttributeResponse
+	}{
+		ComputerExtensionAttributeResponse: attribute,
+	}
+
+	var updatedAttribute ComputerExtensionAttributeResponse
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedAttribute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Computer Extension Attribute by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedAttribute, nil
+}
+
+// DeleteComputerExtensionAttributeByID deletes a computer extension attribute by its ID.
+func (c *Client) DeleteComputerExtensionAttributeByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriComputerExtensionAttributes, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete Computer Extension Attribute by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteComputerExtensionAttributeByNameByID deletes a computer extension attribute by its name.
+// there is no url directly for deletion by resource name. so it is resolved in a two step process.
+func (c *Client) DeleteComputerExtensionAttributeByNameByID(name string) error {
+	// Step 1: Fetch all extension attributes to find the ID for the given name
+	attributes, err := c.GetComputerExtensionAttributes()
+	if err != nil {
+		return fmt.Errorf("failed to fetch Computer Extension Attributes: %v", err)
+	}
+
+	var attributeID int
+	for _, attribute := range attributes.Results {
+		if attribute.Name == name {
+			attributeID = attribute.ID
+			break
+		}
+	}
+
+	if attributeID == 0 {
+		return fmt.Errorf("no Computer Extension Attribute found with name: %s", name)
+	}
+
+	// Step 2: Use the discovered ID to delete the attribute
+	return c.DeleteComputerExtensionAttributeByID(attributeID)
+}


### PR DESCRIPTION
### Jamf Pro Classic API - Computer Extension Attributes

- [ ] ✅ GET `/JSSResource/computerextensionattributes` - GetComputerExtensionAttributes gets a list of all computer extension attributes.
- [ ] ✅ GET `/JSSResource/computerextensionattributes/id/{id}` - GetComputerExtensionAttributeByID retrieves a computer extension attribute by its ID.
- [ ] ✅ GET `/JSSResource/computerextensionattributes/name/{name}` - GetComputerExtensionAttributeByName retrieves a computer extension attribute by its name.
- [ ] ✅ POST `/JSSResource/computerextensionattributes/id/0` - CreateComputerExtensionAttribute creates a new computer extension attribute.
- [ ] ✅ PUT `/JSSResource/computerextensionattributes/id/{id}` - UpdateComputerExtensionAttributeByID updates an existing computer extension attribute by its ID.
- [ ] ✅ PUT `/JSSResource/computerextensionattributes/name/{name}` - UpdateComputerExtensionAttributeByName updates a computer extension attribute by its name.
- [ ] ✅ DELETE `/JSSResource/computerextensionattributes/id/{id}` - DeleteComputerExtensionAttributeByID deletes a computer extension attribute by its ID.
- [ ] ⚠️ DELETE (Complex Operation) - `DeleteComputerExtensionAttributeByNameByID` deletes a computer extension attribute by its name (involves fetching ID by name first). 