### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ DELETE `/api/v1/api-integrations/{id}` - DeleteApiIntegrationByID deletes an API integration by its ID.
 - [ ] ✅ DELETE `/api/v1/api-integrations` followed by searching by name - DeleteApiIntegrationByName deletes an API integration by its display name.
 
+### Jamf Pro API Role Privileges - /api/v1/api-role-privileges
+
+- [ ] ✅ GET `/api/v1/api-role-privileges` - `GetJamfAPIPrivileges` fetches a list of Jamf API role privileges.
+- [ ] ✅ GET `/api/v1/api-role-privileges/search?name={name}&limit={limit}` - `GetJamfAPIPrivilegesByName` fetches a list of Jamf API role privileges by name.
+
+
 ### Jamf Pro API Roles - /api/v1/api-roles
 
 - [ ] ✅ GET `/api/v1/api-roles` - GetJamfAPIRoles fetches all API roles.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 ### Jamf Pro API Role Privileges - /api/v1/api-role-privileges
 
 - [ ] ✅ GET `/api/v1/api-role-privileges` - `GetJamfAPIPrivileges` fetches a list of Jamf API role privileges.
-- [ ] ✅ GET `/api/v1/api-role-privileges/search?name={name}&limit={limit}` - `GetJamfAPIPrivilegesByName` fetches a list of Jamf API role privileges by name.
+- [ ] ✅ GET `/api/v1/api-role-privileges/search?name={name}&limit={limit}` - `GetJamfAPIPrivilegesByName` fetches a Jamf API role privileges by name.
 
 
 ### Jamf Pro API Roles - /api/v1/api-roles

--- a/examples/jamf_api_privileges/GetAPIRolePrivByName/GetAPIRolePrivByName.go
+++ b/examples/jamf_api_privileges/GetAPIRolePrivByName/GetAPIRolePrivByName.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Fetch API role privileges by name
+	name := "Read API Roles" // Replace with the privilege name you want to search for
+	limit := 15              // Replace with your desired limit for results
+	apiPrivileges, err := client.GetJamfAPIPrivilegesByName(name, limit)
+	if err != nil {
+		log.Fatalf("Error fetching API role privileges by name: %v", err)
+	}
+
+	// Pretty print the fetched API role privileges using JSON marshaling
+	privilegesJSON, err := json.MarshalIndent(apiPrivileges, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling API role privileges data: %v", err)
+	}
+	fmt.Println("Fetched API Role Privileges by Name:", string(privilegesJSON))
+}

--- a/examples/jamf_api_privileges/GetJamfAPIPrivileges/GetJamfAPIPrivileges.go
+++ b/examples/jamf_api_privileges/GetJamfAPIPrivileges/GetJamfAPIPrivileges.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Fetch API role privileges
+	apiPrivileges, err := client.GetJamfAPIPrivileges()
+	if err != nil {
+		log.Fatalf("Error fetching API role privileges: %v", err)
+	}
+
+	// Pretty print the fetched API role privileges using JSON marshaling
+	privilegesJSON, err := json.MarshalIndent(apiPrivileges, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling API role privileges data: %v", err)
+	}
+	fmt.Println("Fetched API Role Privileges:", string(privilegesJSON))
+}

--- a/sdk/jamfpro/jamfproapi_api_role_privileges.go
+++ b/sdk/jamfpro/jamfproapi_api_role_privileges.go
@@ -1,0 +1,54 @@
+// jamfproapi_api_role_privileges.go
+// Jamf Pro Api - API Role Privileges
+// API reference: https://developer.jamf.com/jamf-pro/reference/api-role-privileges
+// Jamf Pro API requires the structs to support a JSON data structure.
+
+package jamfpro
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const uriApiRolePrivileges = "/api/v1/api-role-privileges"
+
+// ResponseApiRolePrivileges represents the structure of the response for fetching API role privileges
+type ResponseApiRolePrivileges struct {
+	Privileges []string `json:"privileges"`
+}
+
+// GetJamfAPIPrivileges fetches a list of Jamf API role privileges
+func (c *Client) GetJamfAPIPrivileges() (*ResponseApiRolePrivileges, error) {
+	var privilegesList ResponseApiRolePrivileges
+	resp, err := c.HTTP.DoRequest("GET", uriApiRolePrivileges, nil, &privilegesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Jamf API role privileges: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &privilegesList, nil
+}
+
+// GetJamfAPIPrivilegesByName fetches a list of Jamf API role privileges by name
+func (c *Client) GetJamfAPIPrivilegesByName(name string, limit int) (*ResponseApiRolePrivileges, error) {
+	// Encode the name parameter to handle special characters
+	encodedName := url.QueryEscape(name)
+
+	// Construct the URL with the provided name and limit
+	endpoint := fmt.Sprintf(uriApiRolePrivileges+"/search?name=%s&limit=%d", encodedName, limit)
+
+	var privilegesList ResponseApiRolePrivileges
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &privilegesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Jamf API role privileges by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &privilegesList, nil
+}


### PR DESCRIPTION
Added api-role-privileges sdk coverage with examples

### Jamf Pro API Role Privileges - /api/v1/api-role-privileges

- [ ] ✅ GET `/api/v1/api-role-privileges` - `GetJamfAPIPrivileges` fetches a list of Jamf API role privileges.
- [ ] ✅ GET `/api/v1/api-role-privileges/search?name={name}&limit={limit}` - `GetJamfAPIPrivilegesByName` fetches a Jamf API role privileges by name.
