### PR TITLE
Added coverage for jamf pro api categories with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ DELETE `/JSSResource/allowedfileextensions/id/{id}` - DeleteAllowedFileExtensionByID deletes an existing allowed file extension by ID
 - [ ] ✅ DELETE `/JSSResource/allowedfileextensions/extension/{extensionName}` - DeleteAllowedFileExtensionByNameByID deletes an existing allowed file extension by resolving its name to an ID
 
+### Jamf Pro API - Categories
+
+- [ ] ✅ GET `/api/v1/categories` - `GetCategories` retrieves categories based on query parameters.
+- [ ] ✅ GET `/api/v1/categories/{id}` - `GetCategoryByID` retrieves a category by its ID.
+- [ ] ✅ GET `/api/v1/categories/name/{name}` - `GetCategoryNameByID` retrieves a category by its name and then retrieves its details using its ID.
+- [ ] ✅ POST `/api/v1/categories` - `CreateCategory` creates a new category.
+- [ ] ✅ PUT `/api/v1/categories/{id}` - `UpdateCategoryByID` updates an existing category by its ID.
+- [ ] ✅ PUT `UpdateCategoryByNameByID` updates a category by its name and then updates its details using its ID.
+- [ ] ✅ DELETE `/api/v1/categories/{id}` - `DeleteCategoryByID` deletes a category by its ID.
+- [ ] ✅ DELETE `DeleteCategoryByNameByID` deletes a category by its name after inferring its ID.
+- [ ] ✅ POST `/api/v1/categories/delete-multiple` - `DeleteMultipleCategoriesByID` deletes multiple categories by their IDs.
+
 ### Jamf Pro Classic API - Computer Groups
 
 - [ ] ✅ GET `/JSSResource/computergroups` - GetComputerGroups fetches all computer groups.

--- a/examples/categories/CreateCategory/CreateCategory.go
+++ b/examples/categories/CreateCategory/CreateCategory.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the Jamf Pro API
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro API client
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the category details for creation
+	newCategory := &jamfpro.ResponseCategories{
+		Name:     jamfpro.String("New Category Name"),
+		Priority: jamfpro.Int(1),
+	}
+
+	// Create the category
+	createdCategory, err := client.CreateCategory(newCategory)
+	if err != nil {
+		fmt.Println("Error creating category:", err)
+		return
+	}
+
+	// Print the response
+	fmt.Printf("Created Category with ID: %s and Name: %s\n", jamfpro.StringValue(createdCategory.Id), jamfpro.StringValue(createdCategory.Name))
+}

--- a/examples/categories/DeleteCategoryByID/DeleteCategoryByID.go
+++ b/examples/categories/DeleteCategoryByID/DeleteCategoryByID.go
@@ -8,16 +8,13 @@ import (
 )
 
 func main() {
-	// Define the path to the JSON configuration file inside the main function
 	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
 
-	// Load the client OAuth credentials from the configuration file
 	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
 	if err != nil {
 		log.Fatalf("Failed to load client OAuth configuration: %v", err)
 	}
 
-	// Configuration for the jamfpro
 	config := jamfpro.Config{
 		InstanceName: authConfig.InstanceName,
 		DebugMode:    true,
@@ -26,22 +23,17 @@ func main() {
 		ClientSecret: authConfig.ClientSecret,
 	}
 
-	// Create a new jamfpro client instance
 	client, err := jamfpro.NewClient(config)
 	if err != nil {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// Define a category ID for testing
-	categoryID := "1" // Replace with an actual category ID
+	categoryID := 123 // Replace with the actual category ID you want to delete
 
-	// Call GetCategoryByID function
-	category, err := client.GetCategoryByID(categoryID)
+	err = client.DeleteCategoryByID(categoryID)
 	if err != nil {
-		log.Fatalf("Error fetching category by ID: %v", err)
+		log.Fatalf("Error deleting category: %v", err)
 	}
 
-	// Pretty print the category details
-	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
-		category.Id, category.Name, category.Priority)
+	fmt.Println("Category deleted successfully")
 }

--- a/examples/categories/DeleteCategoryByNameByID/DeleteCategoryByNameByID.go
+++ b/examples/categories/DeleteCategoryByNameByID/DeleteCategoryByNameByID.go
@@ -8,16 +8,13 @@ import (
 )
 
 func main() {
-	// Define the path to the JSON configuration file inside the main function
 	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
 
-	// Load the client OAuth credentials from the configuration file
 	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
 	if err != nil {
 		log.Fatalf("Failed to load client OAuth configuration: %v", err)
 	}
 
-	// Configuration for the jamfpro
 	config := jamfpro.Config{
 		InstanceName: authConfig.InstanceName,
 		DebugMode:    true,
@@ -26,22 +23,17 @@ func main() {
 		ClientSecret: authConfig.ClientSecret,
 	}
 
-	// Create a new jamfpro client instance
 	client, err := jamfpro.NewClient(config)
 	if err != nil {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// Define a category ID for testing
-	categoryID := "1" // Replace with an actual category ID
+	categoryName := "Updated Applications Category Name" // Replace with the actual category name you want to delete
 
-	// Call GetCategoryByID function
-	category, err := client.GetCategoryByID(categoryID)
+	err = client.DeleteCategoryByNameByID(categoryName)
 	if err != nil {
-		log.Fatalf("Error fetching category by ID: %v", err)
+		log.Fatalf("Error deleting category: %v", err)
 	}
 
-	// Pretty print the category details
-	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
-		category.Id, category.Name, category.Priority)
+	fmt.Println("Category deleted successfully")
 }

--- a/examples/categories/DeleteMultipleCategoriesByID/DeleteMultipleCategoriesByID.go
+++ b/examples/categories/DeleteMultipleCategoriesByID/DeleteMultipleCategoriesByID.go
@@ -1,3 +1,6 @@
+// This uses a seperate function to the other delete operations, so it is intentionally
+// included as a seperate example.
+
 package main
 
 import (
@@ -8,7 +11,7 @@ import (
 )
 
 func main() {
-	// Define the path to the JSON configuration file inside the main function
+	// Define the path to the JSON configuration file
 	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
 
 	// Load the client OAuth credentials from the configuration file
@@ -17,7 +20,7 @@ func main() {
 		log.Fatalf("Failed to load client OAuth configuration: %v", err)
 	}
 
-	// Configuration for the jamfpro
+	// Configuration for the Jamf Pro client
 	config := jamfpro.Config{
 		InstanceName: authConfig.InstanceName,
 		DebugMode:    true,
@@ -26,22 +29,20 @@ func main() {
 		ClientSecret: authConfig.ClientSecret,
 	}
 
-	// Create a new jamfpro client instance
+	// Create a new Jamf Pro client instance
 	client, err := jamfpro.NewClient(config)
 	if err != nil {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// Define a category ID for testing
-	categoryID := "1" // Replace with an actual category ID
+	// Define the category IDs to delete as strings
+	categoryIDsToDelete := []string{"3", "4"} // Replace with the actual category IDs you want to delete
 
-	// Call GetCategoryByID function
-	category, err := client.GetCategoryByID(categoryID)
+	// Call DeleteMultipleCategoriesByID function
+	err = client.DeleteMultipleCategoriesByID(categoryIDsToDelete)
 	if err != nil {
-		log.Fatalf("Error fetching category by ID: %v", err)
+		log.Fatalf("Error deleting multiple categories: %v", err)
 	}
 
-	// Pretty print the category details
-	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
-		category.Id, category.Name, category.Priority)
+	fmt.Println("Categories deleted successfully")
 }

--- a/examples/categories/GetCategories/GetCategories.go
+++ b/examples/categories/GetCategories/GetCategories.go
@@ -48,6 +48,6 @@ func main() {
 	// Print the fetched categories
 	fmt.Println("Fetched Categories:")
 	for _, category := range categories.Results {
-		fmt.Printf("ID: %s, Name: %s, Priority: %d\n", *category.Id, *category.Name, *category.Priority)
+		fmt.Printf("ID: %s, Name: %s, Priority: %d\n", category.Id, category.Name, category.Priority)
 	}
 }

--- a/examples/categories/GetCategories/GetCategories.go
+++ b/examples/categories/GetCategories/GetCategories.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the query parameters
+	page := 0
+	pageSize := 100
+	sort := "id:asc"
+	filter := ""
+
+	// Call the GetCategories function
+	categories, err := client.GetCategories(page, pageSize, sort, filter)
+	if err != nil {
+		fmt.Printf("Error fetching categories: %v\n", err)
+		return
+	}
+
+	// Print the fetched categories
+	fmt.Println("Fetched Categories:")
+	for _, category := range categories.Results {
+		fmt.Printf("ID: %s, Name: %s, Priority: %d\n", *category.Id, *category.Name, *category.Priority)
+	}
+}

--- a/examples/categories/GetCategoryByID/GetCategoryByID.go
+++ b/examples/categories/GetCategoryByID/GetCategoryByID.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define a category ID for testing
+	categoryID := "1" // Replace with an actual category ID
+
+	// Call GetCategoryByID function
+	category, err := client.GetCategoryByID(categoryID)
+	if err != nil {
+		log.Fatalf("Error fetching category by ID: %v", err)
+	}
+
+	// Pretty print the category details
+	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
+		*category.Id, *category.Name, *category.Priority)
+}

--- a/examples/categories/GetCategoryNameByID/GetCategoryNameByID.go
+++ b/examples/categories/GetCategoryNameByID/GetCategoryNameByID.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json" // Update the path to your configuration file
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the category name to search for
+	categoryName := "test" // Replace with the desired category name
+
+	// Call GetCategoryNameByID function
+	category, err := client.GetCategoryNameByID(categoryName)
+	if err != nil {
+		log.Fatalf("Error fetching category by name: %v", err)
+	}
+
+	// Print the category details
+	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
+		*category.Id, *category.Name, *category.Priority)
+}

--- a/examples/categories/GetCategoryNameByID/GetCategoryNameByID.go
+++ b/examples/categories/GetCategoryNameByID/GetCategoryNameByID.go
@@ -43,5 +43,5 @@ func main() {
 
 	// Print the category details
 	fmt.Printf("Fetched Category Details:\nID: %s\nName: %s\nPriority: %d\n",
-		*category.Id, *category.Name, *category.Priority)
+		category.Id, category.Name, category.Priority)
 }

--- a/examples/categories/UpdateCategoryByID/UpdateCategoryByID.go
+++ b/examples/categories/UpdateCategoryByID/UpdateCategoryByID.go
@@ -33,22 +33,23 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// Define the new category you want to create
-	newCategory := &jamfpro.ResponseCategories{
-		Name:     "Applications",
-		Priority: 9,
+	// Define the category ID you want to update and the updated category details
+	categoryID := 1 // Replace with the actual category ID you want to update
+	updatedCategory := &jamfpro.ResponseCategories{
+		Name:     "Updated Category Name", // Replace with the updated name
+		Priority: 10,                      // Replace with the updated priority
 	}
 
-	// Call CreateCategory function
-	createdCategory, err := client.CreateCategory(newCategory)
+	// Call UpdateCategoryByID function
+	updatedCategoryResult, err := client.UpdateCategoryByID(categoryID, updatedCategory)
 	if err != nil {
-		log.Fatalf("Error creating category: %v", err)
+		log.Fatalf("Error updating category: %v", err)
 	}
 
-	// Pretty print the created category in JSON
-	categoryJSON, err := json.MarshalIndent(createdCategory, "", "    ") // Indent with 4 spaces
+	// Pretty print the updated category in JSON
+	categoryJSON, err := json.MarshalIndent(updatedCategoryResult, "", "    ") // Indent with 4 spaces
 	if err != nil {
-		log.Fatalf("Error marshaling category data: %v", err)
+		log.Fatalf("Error marshaling updated category data: %v", err)
 	}
-	fmt.Println("Created Category:\n", string(categoryJSON))
+	fmt.Println("Updated Category:\n", string(categoryJSON))
 }

--- a/examples/categories/UpdateCategoryByNameByID/UpdateCategoryByNameByID.go
+++ b/examples/categories/UpdateCategoryByNameByID/UpdateCategoryByNameByID.go
@@ -33,22 +33,23 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// Define the new category you want to create
-	newCategory := &jamfpro.ResponseCategories{
-		Name:     "Applications",
-		Priority: 9,
+	// Define the category name you want to update and the updated category details
+	categoryName := "Existing Category Name" // Replace with the actual category name you want to update
+	updatedCategory := &jamfpro.ResponseCategories{
+		Name:     "Updated Category Name", // Replace with the updated name
+		Priority: 10,                      // Replace with the updated priority
 	}
 
-	// Call CreateCategory function
-	createdCategory, err := client.CreateCategory(newCategory)
+	// Call UpdateCategoryByNameByID function
+	updatedCategoryResult, err := client.UpdateCategoryByNameByID(categoryName, updatedCategory)
 	if err != nil {
-		log.Fatalf("Error creating category: %v", err)
+		log.Fatalf("Error updating category: %v", err)
 	}
 
-	// Pretty print the created category in JSON
-	categoryJSON, err := json.MarshalIndent(createdCategory, "", "    ") // Indent with 4 spaces
+	// Pretty print the updated category in JSON
+	categoryJSON, err := json.MarshalIndent(updatedCategoryResult, "", "    ") // Indent with 4 spaces
 	if err != nil {
-		log.Fatalf("Error marshaling category data: %v", err)
+		log.Fatalf("Error marshaling updated category data: %v", err)
 	}
-	fmt.Println("Created Category:\n", string(categoryJSON))
+	fmt.Println("Updated Category:\n", string(categoryJSON))
 }

--- a/sdk/jamfpro/classicapi_accounts.go
+++ b/sdk/jamfpro/classicapi_accounts.go
@@ -1,6 +1,7 @@
 // classicapi_accounts.go
-// Jamf Pro Classic Api
-// Classic API requires the structs to support both XML and JSON.
+// Jamf Pro Classic Api - Accounts
+// api reference: https://developer.jamf.com/jamf-pro/reference/accounts
+// Classic API requires the structs to support an XML data structure.
 
 package jamfpro
 

--- a/sdk/jamfpro/classicapi_allowed_file_extensions.go
+++ b/sdk/jamfpro/classicapi_allowed_file_extensions.go
@@ -1,6 +1,7 @@
 // classicapi_allowed_file_extensions.go
-// Jamf Pro Classic Api
-// Classic API requires the structs to support both XML and JSON.
+// Jamf Pro Classic Api - Allowed File Extensions
+// api reference: https://developer.jamf.com/jamf-pro/reference/allowedfileextensions
+// Classic API requires the structs to support an XML data structure.
 
 package jamfpro
 


### PR DESCRIPTION
Added coverage for jamf pro api categories with examples
### Jamf Pro API - Categories

- [ ] ✅ GET `/api/v1/categories` - `GetCategories` retrieves categories based on query parameters.
- [ ] ✅ GET `/api/v1/categories/{id}` - `GetCategoryByID` retrieves a category by its ID.
- [ ] ✅ GET `/api/v1/categories/name/{name}` - `GetCategoryNameByID` retrieves a category by its name and then retrieves its details using its ID.
- [ ] ✅ POST `/api/v1/categories` - `CreateCategory` creates a new category.
- [ ] ✅ PUT `/api/v1/categories/{id}` - `UpdateCategoryByID` updates an existing category by its ID.
- [ ] ✅ PUT `UpdateCategoryByNameByID` updates a category by its name and then updates its details using its ID.
- [ ] ✅ DELETE `/api/v1/categories/{id}` - `DeleteCategoryByID` deletes a category by its ID.
- [ ] ✅ DELETE `DeleteCategoryByNameByID` deletes a category by its name after inferring its ID.
- [ ] ✅ POST `/api/v1/categories/delete-multiple` - `DeleteMultipleCategoriesByID` deletes multiple categories by their IDs.