### PR TITLE
Added to SDK Jamf Pro Classic API Policies and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,19 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ DELETE `/JSSResource/osxconfigurationprofiles/id/{id}` - DeleteMacOSConfigurationProfileByID deletes an existing macOS configuration profile by ID.
 - [ ] ✅ DELETE `/JSSResource/osxconfigurationprofiles/name/{name}` - DeleteMacOSConfigurationProfileByName deletes an existing macOS configuration profile by its name.
 
+### Policies - /JSSResource/policies
+
+- [ ] ✅ GET `/JSSResource/policies` - GetPolicies retrieves a list of all policies
+- [ ] ✅ GET `/JSSResource/policies/id/{id}` - GetPolicyByID retrieves the details of a policy by its ID
+- [ ] ✅ GET `/JSSResource/policies/name/{name}` - GetPolicyByName retrieves a policy by its name
+- [ ] ✅ GET `/JSSResource/policies/category/{category}` - GetPolicyByCategory retrieves policies by their category
+- [ ] ✅ GET `/JSSResource/policies/createdBy/{createdBy}` - GetPoliciesByType retrieves policies by the type of entity that created them
+- [ ] ✅ POST `/JSSResource/policies/id/0` - CreatePolicy creates a new policy
+- [ ] ✅ PUT `/JSSResource/policies/id/{id}` - UpdatePolicyByID updates an existing policy by its ID
+- [ ] ✅ PUT `/JSSResource/policies/name/{name}` - UpdatePolicyByName updates an existing policy by its name
+- [ ] ✅ DELETE `/JSSResource/policies/id/{id}` - DeletePolicyByID deletes a policy by its ID
+- [ ] ✅ DELETE `/JSSResource/policies/name/{name}` - DeletePolicyByName deletes a policy by its name
+
 ### Scripts - /JSSResource/scripts
 
 - [ ] ✅ GET `/JSSResource/scripts` - GetScripts retrieves all scripts.

--- a/examples/policies/CreatePolicy/CreatePolicy.go
+++ b/examples/policies/CreatePolicy/CreatePolicy.go
@@ -36,11 +36,104 @@ func main() {
 	// Define a new policy with all required fields
 	newPolicy := &jamfpro.ResponsePolicy{
 		General: jamfpro.PolicyGeneral{
-			Name:    "Firefox",
-			Enabled: false,
-			Trigger: "string",
+			Name:                       "firefox",
+			Enabled:                    false,
+			Trigger:                    "EVENT",
+			TriggerCheckin:             false,
+			TriggerEnrollmentComplete:  false,
+			TriggerLogin:               false,
+			TriggerLogout:              false,
+			TriggerNetworkStateChanged: false,
+			TriggerStartup:             false,
+			Frequency:                  "Once per computer",
+			RetryEvent:                 "none",
+			RetryAttempts:              -1,
+			NotifyOnEachFailedRetry:    false,
+			LocationUserOnly:           false,
+			TargetDrive:                "/",
+			Offline:                    false,
+		},
+		SelfService: jamfpro.PolicySelfService{
+			UseForSelfService:           false,
+			SelfServiceDisplayName:      "",
+			InstallButtonText:           "Install",
+			ReinstallButtonText:         "",
+			SelfServiceDescription:      "",
+			ForceUsersToViewDescription: false,
+			//SelfServiceIcon:             jamfpro.Icon{ID: -1, Filename: "", URI: ""},
+			FeatureOnMainPage: false,
+			SelfServiceCategories: jamfpro.PolicySelfServiceCategory{
+				Category: jamfpro.PolicyCategory{
+					//ID:        "-1",
+					//Name:      "None",
+					DisplayIn: false, // or true, depending on your requirements
+					FeatureIn: false, // or true, depending on your requirements
+				},
+			},
+		},
+		AccountMaintenance: jamfpro.PolicyAccountMaintenance{
+			ManagementAccount: jamfpro.PolicyManagementAccount{
+				Action:                "doNotChange",
+				ManagedPassword:       "",
+				ManagedPasswordLength: 0,
+			},
+			OpenFirmwareEfiPassword: jamfpro.PolicyOpenFirmwareEfiPassword{
+				OfMode:           "none",
+				OfPassword:       "",
+				OfPasswordSHA256: "",
+			},
+		},
+		Maintenance: jamfpro.PolicyMaintenance{
+			Recon:                    false,
+			ResetName:                false,
+			InstallAllCachedPackages: false,
+			Heal:                     false,
+			Prebindings:              false,
+			Permissions:              false,
+			Byhost:                   false,
+			SystemCache:              false,
+			UserCache:                false,
+			Verify:                   false,
+		},
+		FilesProcesses: jamfpro.PolicyFilesProcesses{
+			DeleteFile:           false,
+			UpdateLocateDatabase: false,
+			SpotlightSearch:      "",
+			SearchForProcess:     "",
+			KillProcess:          false,
+			RunCommand:           "",
+		},
+		UserInteraction: jamfpro.PolicyUserInteraction{
+			MessageStart:          "",
+			AllowUserToDefer:      false,
+			AllowDeferralUntilUtc: "",
+			AllowDeferralMinutes:  0,
+			MessageFinish:         "",
+		},
+		/*DiskEncryption: jamfpro.PolicyDiskEncryption{
+			Action:                        "none",
+			DiskEncryptionConfigurationID: 0,
+			AuthRestart:                   false,
+			//RemediateKeyType:                       "",
+			//RemediateDiskEncryptionConfigurationID: 0,
+		},*/
+		Reboot: jamfpro.PolicyReboot{
+			Message:                     "This computer will restart in 5 minutes. Please save anything you are working on and log out by choosing Log Out from the bottom of the Apple menu.",
+			StartupDisk:                 "Current Startup Disk",
+			SpecifyStartup:              "",
+			NoUserLoggedIn:              "Do not restart",
+			UserLoggedIn:                "Do not restart",
+			MinutesUntilReboot:          5,
+			StartRebootTimerImmediately: false,
+			FileVault2Reboot:            false,
 		},
 	}
+
+	policyXML, err := xml.MarshalIndent(newPolicy, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling policy data: %v", err)
+	}
+	fmt.Println("Policy Details to be Sent:\n", string(policyXML))
 
 	// Call CreatePolicy function
 	createdPolicy, err := client.CreatePolicyByID(newPolicy)
@@ -49,7 +142,7 @@ func main() {
 	}
 
 	// Pretty print the created policy details in XML
-	policyXML, err := xml.MarshalIndent(createdPolicy, "", "    ") // Indent with 4 spaces
+	policyXML, err = xml.MarshalIndent(createdPolicy, "", "    ") // Indent with 4 spaces and use '='
 	if err != nil {
 		log.Fatalf("Error marshaling policy details data: %v", err)
 	}

--- a/examples/policies/CreatePolicy/CreatePolicy.go
+++ b/examples/policies/CreatePolicy/CreatePolicy.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define a new policy with all required fields
+	newPolicy := &jamfpro.ResponsePolicy{
+		General: jamfpro.PolicyGeneral{
+			Name:    "Firefox",
+			Enabled: false,
+			Trigger: "string",
+		},
+	}
+
+	// Call CreatePolicy function
+	createdPolicy, err := client.CreatePolicyByID(newPolicy)
+	if err != nil {
+		log.Fatalf("Error creating policy: %v", err)
+	}
+
+	// Pretty print the created policy details in XML
+	policyXML, err := xml.MarshalIndent(createdPolicy, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Created Policy Details:\n", string(policyXML))
+}

--- a/examples/policies/DeletePolicyByID/DeletePolicyByID.go
+++ b/examples/policies/DeletePolicyByID/DeletePolicyByID.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the policy ID to be deleted
+	policyID := 123 // Replace with the actual policy ID
+
+	// Delete the policy by ID
+	err = client.DeletePolicyByID(policyID) // Changed here from := to =
+	if err != nil {
+		log.Fatalf("Error deleting policy: %v", err)
+	}
+
+	fmt.Println("Policy deleted successfully.")
+}

--- a/examples/policies/DeletePolicyByName/DeletePolicyByName.go
+++ b/examples/policies/DeletePolicyByName/DeletePolicyByName.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the policy name to be deleted
+	policyName := "PolicyName" // Replace with the actual policy name
+
+	// Delete the policy by name
+	err = client.DeletePolicyByName(policyName) // Changed here from := to =
+	if err != nil {
+		log.Fatalf("Error deleting policy: %v", err)
+	}
+
+	fmt.Println("Policy deleted successfully.")
+}

--- a/examples/policies/GetPolicies/GetPolicies.go
+++ b/examples/policies/GetPolicies/GetPolicies.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instanceclient,
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	policies, err := client.GetPolicies()
+	if err != nil {
+		log.Fatalf("Error fetching policies: %v", err)
+	}
+
+	fmt.Println("Retrieved Policies:")
+	for _, policy := range policies.Policy {
+		fmt.Printf("ID: %d, Name: %s\n", policy.ID, policy.Name)
+	}
+}

--- a/examples/policies/GetPoliciesByType/GetPoliciesByType.go
+++ b/examples/policies/GetPoliciesByType/GetPoliciesByType.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the createdBy parameter for testing
+	createdBy := "jss" // Can be either 'casper' or 'jss'
+
+	// Call GetPoliciesByType function
+	policies, err := client.GetPoliciesByType(createdBy)
+	if err != nil {
+		log.Fatalf("Error fetching policies by type: %v", err)
+	}
+
+	// Pretty print the policies details in XML
+	policiesXML, err := xml.MarshalIndent(policies, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling policies details data: %v", err)
+	}
+	fmt.Println("Fetched Policies Details:\n", string(policiesXML))
+}

--- a/examples/policies/GetPolicyByCategory/GetPolicyByCategory.go
+++ b/examples/policies/GetPolicyByCategory/GetPolicyByCategory.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define a policy category for testing
+	policyCategory := "YourPolicyCategory"
+
+	// Call GetPolicyByCategory function
+	policies, err := client.GetPolicyByCategory(policyCategory)
+	if err != nil {
+		log.Fatalf("Error fetching policies by category: %v", err)
+	}
+
+	// Pretty print the policies in XML
+	policiesXML, err := xml.MarshalIndent(policies, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling policies data: %v", err)
+	}
+	fmt.Println("Fetched Policies by Category:\n", string(policiesXML))
+}

--- a/examples/policies/GetPolicyByID/GetPolicyByID.go
+++ b/examples/policies/GetPolicyByID/GetPolicyByID.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instanceclient,
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define a policy ID for testing
+	policyID := 2 // Replace with the actual policy ID you want to fetch
+
+	// Call GetPolicyByID function
+	policy, err := client.GetPolicyByID(policyID)
+	if err != nil {
+		log.Fatalf("Error fetching policy by ID: %v", err)
+	}
+
+	// Pretty print the policy details in XML
+	policyXML, err := xml.MarshalIndent(policy, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Fetched Policy Details:\n", string(policyXML))
+}

--- a/examples/policies/GetPolicyByName/GetPolicyByName.go
+++ b/examples/policies/GetPolicyByName/GetPolicyByName.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file inside the main function
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define a policy name for testing
+	policyName := "test"
+
+	// Call GetPolicyByName function
+	policy, err := client.GetPolicyByName(policyName)
+	if err != nil {
+		log.Fatalf("Error fetching policy by name: %v", err)
+	}
+
+	// Pretty print the policy details in XML
+	policyXML, err := xml.MarshalIndent(policy, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Fetched Policy Details:\n", string(policyXML))
+}

--- a/examples/policies/UpdatePolicyByID/UpdatePolicyByID.go
+++ b/examples/policies/UpdatePolicyByID/UpdatePolicyByID.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the policy ID to be updated
+	policyID := 6 // Replace with the actual policy ID
+
+	// Fetch the existing policy by ID
+	policy, err := client.GetPolicyByID(policyID)
+	if err != nil {
+		log.Fatalf("Error fetching policy: %v", err)
+	}
+
+	// Make changes to the policy
+	policy.General.Name = "Updated Policy Name"
+	policy.General.Enabled = true
+
+	// Update the policy
+	updatedPolicy, err := client.UpdatePolicyByID(policyID, policy)
+	if err != nil {
+		log.Fatalf("Error updating policy: %v", err)
+	}
+
+	// Print the updated policy details
+	fmt.Printf("Updated Policy: %+v\n", updatedPolicy)
+}

--- a/examples/policies/UpdatePolicyByName/UpdatePolicyByName.go
+++ b/examples/policies/UpdatePolicyByName/UpdatePolicyByName.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the policy name to be updated
+	policyName := "test" // Replace with the actual policy name
+
+	// Fetch the existing policy by name
+	policy, err := client.GetPolicyByName(policyName)
+	if err != nil {
+		log.Fatalf("Error fetching policy: %v", err)
+	}
+
+	// Make changes to the policy
+	policy.General.Enabled = true
+	policy.SelfService.UseForSelfService = true
+	policy.SelfService.SelfServiceDisplayName = "Install Firefox"
+
+	// Update the policy
+	updatedPolicy, err := client.UpdatePolicyByName(policyName, policy)
+	if err != nil {
+		log.Fatalf("Error updating policy: %v", err)
+	}
+
+	// Print the updated policy details
+	fmt.Printf("Updated Policy: %+v\n", updatedPolicy)
+}

--- a/sdk/jamfpro/classicapi_network_segments.go
+++ b/sdk/jamfpro/classicapi_network_segments.go
@@ -1,7 +1,7 @@
 // classicapi_network_segments.go
-// Jamf Pro Api - Network Segments
+// Jamf Pro Classic Api  - Network Segments
 // api reference: https://developer.jamf.com/jamf-pro/reference/networksegments
-// Jamf Pro API requires the structs to support an XML data structure.
+// Jamf Pro Classic Api requires the structs to support an XML data structure.
 
 package jamfpro
 

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -526,3 +526,33 @@ func (c *Client) UpdatePolicyByName(name string, policy *ResponsePolicy) (*Respo
 
 	return &updatedPolicy, nil
 }
+
+// DeletePolicyByID deletes a policy by its ID.
+func (c *Client) DeletePolicyByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPolicies, id)
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeletePolicyByName deletes a policy by its name.
+func (c *Client) DeletePolicyByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPolicies, name)
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -60,17 +60,17 @@ type PolicyGeneral struct {
 	LocationUserOnly           bool                      `xml:"location_user_only"`
 	TargetDrive                string                    `xml:"target_drive,omitempty"`
 	Offline                    bool                      `xml:"offline"`
-	Category                   PolicyCategory            `xml:"category"`
+	Category                   PolicyCategory            `xml:"category,omitempty"`
 	DateTimeLimitations        PolicyDateTimeLimitations `xml:"date_time_limitations,omitempty"`
 	NetworkLimitations         PolicyNetworkLimitations  `xml:"network_limitations,omitempty"`
 	OverrideDefaultSettings    PolicyOverrideSettings    `xml:"override_default_settings,omitempty"`
 	NetworkRequirements        string                    `xml:"network_requirements,omitempty"`
-	Site                       PolicySite                `xml:"site,omitempty"`
+	Site                       PolicySite                `xml:"site"`
 }
 
 type PolicyCategory struct {
-	ID        int    `xml:"id"`
-	Name      string `xml:"name"`
+	ID        string `xml:"id,omitempty"`
+	Name      string `xml:"name,omitempty"`
 	DisplayIn bool   `xml:"display_in,omitempty"`
 	FeatureIn bool   `xml:"feature_in,omitempty"`
 }
@@ -106,8 +106,8 @@ type PolicyOverrideSettings struct {
 }
 
 type PolicySite struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
 }
 
 // PolicyScope represents the scope of the policy
@@ -194,15 +194,15 @@ type PolicySelfService struct {
 	ReinstallButtonText         string                    `xml:"re_install_button_text"`
 	SelfServiceDescription      string                    `xml:"self_service_description"`
 	ForceUsersToViewDescription bool                      `xml:"force_users_to_view_description"`
-	SelfServiceIcon             PolicySelfServiceIcon     `xml:"self_service_icon"`
+	SelfServiceIcon             PolicySelfServiceIcon     `xml:"self_service_icon,omitempty"`
 	FeatureOnMainPage           bool                      `xml:"feature_on_main_page"`
 	SelfServiceCategories       PolicySelfServiceCategory `xml:"self_service_categories"`
 }
 
 type PolicySelfServiceIcon struct {
-	ID       int    `xml:"id"`
-	Filename string `xml:"filename"`
-	URI      string `xml:"uri"`
+	ID       int    `xml:"id,omitempty"`
+	Filename string `xml:"filename,omitempty"`
+	URI      string `xml:"uri,omitempty"`
 }
 
 type PolicySelfServiceCategory struct {
@@ -350,8 +350,8 @@ type PolicyDiskEncryption struct {
 	Action                                 string `xml:"action"`
 	DiskEncryptionConfigurationID          int    `xml:"disk_encryption_configuration_id"`
 	AuthRestart                            bool   `xml:"auth_restart"`
-	RemediateKeyType                       string `xml:"remediate_key_type"`
-	RemediateDiskEncryptionConfigurationID int    `xml:"remediate_disk_encryption_configuration_id"`
+	RemediateKeyType                       string `xml:"remediate_key_type,omitempty"`
+	RemediateDiskEncryptionConfigurationID int    `xml:"remediate_disk_encryption_configuration_id,omitempty"`
 }
 
 // PolicyReboot represents the reboot settings of a policy
@@ -475,4 +475,54 @@ func (c *Client) CreatePolicyByID(policy *ResponsePolicy) (*ResponsePolicy, erro
 	}
 
 	return &responsePolicy, nil
+}
+
+// UpdatePolicyByID updates an existing policy by its ID.
+func (c *Client) UpdatePolicyByID(id int, policy *ResponsePolicy) (*ResponsePolicy, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPolicies, id)
+
+	// Wrap the policy with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"policy"`
+		*ResponsePolicy
+	}{
+		ResponsePolicy: policy,
+	}
+
+	var updatedPolicy ResponsePolicy
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedPolicy, nil
+}
+
+// UpdatePolicyByName updates an existing policy by its name.
+func (c *Client) UpdatePolicyByName(name string, policy *ResponsePolicy) (*ResponsePolicy, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPolicies, name)
+
+	// Wrap the policy with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"policy"`
+		*ResponsePolicy
+	}{
+		ResponsePolicy: policy,
+	}
+
+	var updatedPolicy ResponsePolicy
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedPolicy, nil
 }

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -1,0 +1,4 @@
+// classicapi_policies.go
+// Jamf Pro Classic Api - Scripts
+// api reference: https://developer.jamf.com/jamf-pro/reference/scripts
+// Jamf Pro Classic Api  requires the structs to support an XML data structure.

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -1,4 +1,478 @@
 // classicapi_policies.go
-// Jamf Pro Classic Api - Scripts
-// api reference: https://developer.jamf.com/jamf-pro/reference/scripts
-// Jamf Pro Classic Api  requires the structs to support an XML data structure.
+// Jamf Pro Classic Api - Policies
+// api reference: https://developer.jamf.com/jamf-pro/reference/policies
+// Jamf Pro Classic Api requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+const uriPolicies = "/JSSResource/policies"
+
+// Policies List Structs
+type ResponsePoliciesList struct {
+	Size   int          `xml:"size"`
+	Policy []PolicyItem `xml:"policy"`
+}
+
+type PolicyItem struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// ResponsePolicy represents the response structure for a single policy
+type ResponsePolicy struct {
+	General              PolicyGeneral              `xml:"general"`
+	Scope                PolicyScope                `xml:"scope,omitempty"`
+	SelfService          PolicySelfService          `xml:"self_service"`
+	PackageConfiguration PolicyPackageConfiguration `xml:"package_configuration,omitempty"`
+	Scripts              PolicyScripts              `xml:"scripts,omitempty"`
+	Printers             PolicyPrinters             `xml:"printers"`
+	DockItems            PolicyDockItems            `xml:"dock_items"`
+	AccountMaintenance   PolicyAccountMaintenance   `xml:"account_maintenance"`
+	Maintenance          PolicyMaintenance          `xml:"maintenance"`
+	FilesProcesses       PolicyFilesProcesses       `xml:"files_processes"`
+	UserInteraction      PolicyUserInteraction      `xml:"user_interaction"`
+	DiskEncryption       PolicyDiskEncryption       `xml:"disk_encryption"`
+	Reboot               PolicyReboot               `xml:"reboot"`
+}
+
+// PolicyGeneral represents the general information of a policy
+type PolicyGeneral struct {
+	ID                         int                       `xml:"id"`
+	Name                       string                    `xml:"name"`
+	Enabled                    bool                      `xml:"enabled"`
+	Trigger                    string                    `xml:"trigger,omitempty"`
+	TriggerCheckin             bool                      `xml:"trigger_checkin"`
+	TriggerEnrollmentComplete  bool                      `xml:"trigger_enrollment_complete"`
+	TriggerLogin               bool                      `xml:"trigger_login"`
+	TriggerLogout              bool                      `xml:"trigger_logout"`
+	TriggerNetworkStateChanged bool                      `xml:"trigger_network_state_changed"`
+	TriggerStartup             bool                      `xml:"trigger_startup"`
+	TriggerOther               string                    `xml:"trigger_other,omitempty"`
+	Frequency                  string                    `xml:"frequency,omitempty"`
+	RetryEvent                 string                    `xml:"retry_event,omitempty"`
+	RetryAttempts              int                       `xml:"retry_attempts,omitempty"`
+	NotifyOnEachFailedRetry    bool                      `xml:"notify_on_each_failed_retry"`
+	LocationUserOnly           bool                      `xml:"location_user_only"`
+	TargetDrive                string                    `xml:"target_drive,omitempty"`
+	Offline                    bool                      `xml:"offline"`
+	Category                   PolicyCategory            `xml:"category"`
+	DateTimeLimitations        PolicyDateTimeLimitations `xml:"date_time_limitations,omitempty"`
+	NetworkLimitations         PolicyNetworkLimitations  `xml:"network_limitations,omitempty"`
+	OverrideDefaultSettings    PolicyOverrideSettings    `xml:"override_default_settings,omitempty"`
+	NetworkRequirements        string                    `xml:"network_requirements,omitempty"`
+	Site                       PolicySite                `xml:"site,omitempty"`
+}
+
+type PolicyCategory struct {
+	ID        int    `xml:"id"`
+	Name      string `xml:"name"`
+	DisplayIn bool   `xml:"display_in,omitempty"`
+	FeatureIn bool   `xml:"feature_in,omitempty"`
+}
+
+type PolicyDateTimeLimitations struct {
+	ActivationDate      string            `xml:"activation_date,omitempty"`
+	ActivationDateEpoch int64             `xml:"activation_date_epoch,omitempty"`
+	ActivationDateUTC   string            `xml:"activation_date_utc,omitempty"`
+	ExpirationDate      string            `xml:"expiration_date,omitempty"`
+	ExpirationDateEpoch int64             `xml:"expiration_date_epoch,omitempty"`
+	ExpirationDateUTC   string            `xml:"expiration_date_utc,omitempty"`
+	NoExecuteOn         PolicyNoExecuteOn `xml:"no_execute_on,omitempty"`
+	NoExecuteStart      string            `xml:"no_execute_start,omitempty"`
+	NoExecuteEnd        string            `xml:"no_execute_end,omitempty"`
+}
+
+type PolicyNoExecuteOn struct {
+	Day string `xml:"day,omitempty"`
+}
+
+type PolicyNetworkLimitations struct {
+	MinimumNetworkConnection string `xml:"minimum_network_connection,omitempty"`
+	AnyIPAddress             bool   `xml:"any_ip_address"`
+	NetworkSegments          string `xml:"network_segments"`
+}
+
+type PolicyOverrideSettings struct {
+	TargetDrive       string `xml:"target_drive,omitempty"`
+	DistributionPoint string `xml:"distribution_point,omitempty"`
+	ForceAfpSmb       bool   `xml:"force_afp_smb,omitempty"`
+	SUS               string `xml:"sus,omitempty"`
+	NetbootServer     string `xml:"netboot_server,omitempty"`
+}
+
+type PolicySite struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// PolicyScope represents the scope of the policy
+type PolicyScope struct {
+	AllComputers   bool                  `xml:"all_computers"`
+	Computers      []PolicyComputer      `xml:"computers>computer,omitempty"`
+	ComputerGroups []PolicyComputerGroup `xml:"computer_groups>computer_group,omitempty"`
+	Buildings      []PolicyBuilding      `xml:"buildings>building,omitempty"`
+	Departments    []PolicyDepartment    `xml:"departments>department,omitempty"`
+	LimitToUsers   PolicyLimitToUsers    `xml:"limit_to_users,omitempty"`
+	Limitations    PolicyLimitations     `xml:"limitations,omitempty"`
+	Exclusions     PolicyExclusions      `xml:"exclusions,omitempty"`
+}
+
+type PolicyComputer struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name,omitempty"`
+	UDID string `xml:"udid,omitempty"`
+}
+
+type PolicyComputerGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyBuilding struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyDepartment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyLimitToUsers struct {
+	UserGroups []string `xml:"user_groups>user_group,omitempty"`
+}
+
+type PolicyLimitations struct {
+	Users           []PolicyUser           `xml:"users>user,omitempty"`
+	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+}
+
+type PolicyUser struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyUserGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyNetworkSegment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+	UID  string `xml:"uid,omitempty"`
+}
+
+type PolicyIBeacon struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyExclusions struct {
+	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
+	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
+	Buildings       []PolicyBuilding       `xml:"buildings>building,omitempty"`
+	Departments     []PolicyDepartment     `xml:"departments>department,omitempty"`
+	Users           []PolicyUser           `xml:"users>user,omitempty"`
+	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+}
+
+// PolicySelfService represents the self service settings of a policy
+type PolicySelfService struct {
+	UseForSelfService           bool                      `xml:"use_for_self_service"`
+	SelfServiceDisplayName      string                    `xml:"self_service_display_name"`
+	InstallButtonText           string                    `xml:"install_button_text"`
+	ReinstallButtonText         string                    `xml:"re_install_button_text"`
+	SelfServiceDescription      string                    `xml:"self_service_description"`
+	ForceUsersToViewDescription bool                      `xml:"force_users_to_view_description"`
+	SelfServiceIcon             PolicySelfServiceIcon     `xml:"self_service_icon"`
+	FeatureOnMainPage           bool                      `xml:"feature_on_main_page"`
+	SelfServiceCategories       PolicySelfServiceCategory `xml:"self_service_categories"`
+}
+
+type PolicySelfServiceIcon struct {
+	ID       int    `xml:"id"`
+	Filename string `xml:"filename"`
+	URI      string `xml:"uri"`
+}
+
+type PolicySelfServiceCategory struct {
+	Category PolicyCategory `xml:"category"`
+}
+
+// PolicyPackageConfiguration represents the package configuration settings of a policy
+type PolicyPackageConfiguration struct {
+	Packages          []PolicyPackage `xml:"packages>package"`
+	DistributionPoint string          `xml:"distribution_point"`
+}
+
+type PolicyPackage struct {
+	ID                int    `xml:"id,omitempty"`
+	Name              string `xml:"name,omitempty"`
+	Action            string `xml:"action,omitempty"`
+	FillUserTemplate  bool   `xml:"fut,omitempty"`
+	FillExistingUsers bool   `xml:"feu,omitempty"`
+	UpdateAutorun     bool   `xml:"update_autorun,omitempty"`
+}
+
+// PolicyScripts represents the scripts settings of a policy
+type PolicyScripts struct {
+	Size   int                `xml:"size"`
+	Script []PolicyScriptItem `xml:"script"`
+}
+
+type PolicyScriptItem struct {
+	ID          string `xml:"id,omitempty"`
+	Name        string `xml:"name,omitempty"`
+	Priority    string `xml:"priority,omitempty"`
+	Parameter4  string `xml:"parameter4,omitempty"`
+	Parameter5  string `xml:"parameter5,omitempty"`
+	Parameter6  string `xml:"parameter6,omitempty"`
+	Parameter7  string `xml:"parameter7,omitempty"`
+	Parameter8  string `xml:"parameter8,omitempty"`
+	Parameter9  string `xml:"parameter9,omitempty"`
+	Parameter10 string `xml:"parameter10,omitempty"`
+	Parameter11 string `xml:"parameter11,omitempty"`
+}
+
+// PolicyPrinters represents the printers settings of a policy
+type PolicyPrinters struct {
+	Size                 int                 `xml:"size"`
+	LeaveExistingDefault bool                `xml:"leave_existing_default"`
+	Printer              []PolicyPrinterItem `xml:"printer"`
+}
+
+type PolicyPrinterItem struct {
+	ID          int    `xml:"id"`
+	Name        string `xml:"name"`
+	Action      string `xml:"action"`
+	MakeDefault bool   `xml:"make_default"`
+}
+
+// PolicyDockItems represents the dock items settings of a policy
+type PolicyDockItems struct {
+	Size     int              `xml:"size"`
+	DockItem []PolicyDockItem `xml:"dock_item"`
+}
+
+type PolicyDockItem struct {
+	ID     int    `xml:"id"`
+	Name   string `xml:"name"`
+	Action string `xml:"action"`
+}
+
+// PolicyAccountMaintenance represents the account maintenance settings of a policy
+type PolicyAccountMaintenance struct {
+	Accounts                []PolicyAccount               `xml:"accounts>account"`
+	DirectoryBindings       []PolicyDirectoryBinding      `xml:"directory_bindings>binding"`
+	ManagementAccount       PolicyManagementAccount       `xml:"management_account"`
+	OpenFirmwareEfiPassword PolicyOpenFirmwareEfiPassword `xml:"open_firmware_efi_password"`
+}
+
+type PolicyAccount struct {
+	Action                 string `xml:"action"`
+	Username               string `xml:"username"`
+	Realname               string `xml:"realname"`
+	Password               string `xml:"password"`
+	ArchiveHomeDirectory   bool   `xml:"archive_home_directory"`
+	ArchiveHomeDirectoryTo string `xml:"archive_home_directory_to"`
+	Home                   string `xml:"home"`
+	Hint                   string `xml:"hint"`
+	Picture                string `xml:"picture"`
+	Admin                  bool   `xml:"admin"`
+	FilevaultEnabled       bool   `xml:"filevault_enabled"`
+	PasswordSha256         string `xml:"password_sha256"`
+}
+
+type PolicyDirectoryBinding struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyManagementAccount struct {
+	Action                string `xml:"action"`
+	ManagedPassword       string `xml:"managed_password"`
+	ManagedPasswordLength int    `xml:"managed_password_length"`
+}
+
+type PolicyOpenFirmwareEfiPassword struct {
+	OfMode           string `xml:"of_mode"`
+	OfPassword       string `xml:"of_password"`
+	OfPasswordSHA256 string `xml:"of_password_sha256"`
+}
+
+// PolicyMaintenance represents the maintenance settings of a policy
+type PolicyMaintenance struct {
+	Recon                    bool `xml:"recon"`
+	ResetName                bool `xml:"reset_name"`
+	InstallAllCachedPackages bool `xml:"install_all_cached_packages"`
+	Heal                     bool `xml:"heal"`
+	Prebindings              bool `xml:"prebindings"`
+	Permissions              bool `xml:"permissions"`
+	Byhost                   bool `xml:"byhost"`
+	SystemCache              bool `xml:"system_cache"`
+	UserCache                bool `xml:"user_cache"`
+	Verify                   bool `xml:"verify"`
+}
+
+// PolicyFilesProcesses represents the files and processes settings of a policy
+type PolicyFilesProcesses struct {
+	SearchByPath         string `xml:"search_by_path"`
+	DeleteFile           bool   `xml:"delete_file"`
+	LocateFile           string `xml:"locate_file"`
+	UpdateLocateDatabase bool   `xml:"update_locate_database"`
+	SpotlightSearch      string `xml:"spotlight_search"`
+	SearchForProcess     string `xml:"search_for_process"`
+	KillProcess          bool   `xml:"kill_process"`
+	RunCommand           string `xml:"run_command"`
+}
+
+// PolicyUserInteraction represents the user interaction settings of a policy
+type PolicyUserInteraction struct {
+	MessageStart          string `xml:"message_start"`
+	AllowUserToDefer      bool   `xml:"allow_user_to_defer"`
+	AllowDeferralUntilUtc string `xml:"allow_deferral_until_utc"`
+	AllowDeferralMinutes  int    `xml:"allow_deferral_minutes"`
+	MessageFinish         string `xml:"message_finish"`
+}
+
+// PolicyDiskEncryption represents the disk encryption settings of a policy
+type PolicyDiskEncryption struct {
+	Action                                 string `xml:"action"`
+	DiskEncryptionConfigurationID          int    `xml:"disk_encryption_configuration_id"`
+	AuthRestart                            bool   `xml:"auth_restart"`
+	RemediateKeyType                       string `xml:"remediate_key_type"`
+	RemediateDiskEncryptionConfigurationID int    `xml:"remediate_disk_encryption_configuration_id"`
+}
+
+// PolicyReboot represents the reboot settings of a policy
+type PolicyReboot struct {
+	Message                     string `xml:"message"`
+	StartupDisk                 string `xml:"startup_disk"`
+	SpecifyStartup              string `xml:"specify_startup"`
+	NoUserLoggedIn              string `xml:"no_user_logged_in"`
+	UserLoggedIn                string `xml:"user_logged_in"`
+	MinutesUntilReboot          int    `xml:"minutes_until_reboot"`
+	StartRebootTimerImmediately bool   `xml:"start_reboot_timer_immediately"`
+	FileVault2Reboot            bool   `xml:"file_vault_2_reboot"`
+}
+
+// GetPolicies retrieves a list of all policies.
+func (c *Client) GetPolicies() (*ResponsePoliciesList, error) {
+	endpoint := uriPolicies
+
+	var policiesList ResponsePoliciesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &policiesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch all policies: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &policiesList, nil
+}
+
+// GetPolicyByID retrieves the details of a policy by its ID.
+func (c *Client) GetPolicyByID(id int) (*ResponsePolicy, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPolicies, id)
+
+	var policyDetails ResponsePolicy
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &policyDetails)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch policy by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &policyDetails, nil
+}
+
+// GetPolicyByName retrieves a policy by its name.
+func (c *Client) GetPolicyByName(name string) (*ResponsePolicy, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPolicies, name)
+
+	var policyDetails ResponsePolicy
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &policyDetails)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch policy by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &policyDetails, nil
+}
+
+// GetPolicyByCategory retrieves policies by their category.
+func (c *Client) GetPolicyByCategory(category string) (*ResponsePoliciesList, error) {
+	endpoint := fmt.Sprintf("%s/category/%s", uriPolicies, category)
+
+	var policiesList ResponsePoliciesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &policiesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch policies by category: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &policiesList, nil
+}
+
+// GetPoliciesByType retrieves policies by the type of entity that created them.
+// The createdBy param can be either the value 'casper' which refers to Casper Remote. Or the value 'jss', which refers to policies created in the GUI or via the API.
+func (c *Client) GetPoliciesByType(createdBy string) (*ResponsePoliciesList, error) {
+	endpoint := fmt.Sprintf("%s/createdBy/%s", uriPolicies, createdBy)
+
+	var policiesList ResponsePoliciesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &policiesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch policies by type: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &policiesList, nil
+}
+
+// CreatePolicy creates a new policy.
+func (c *Client) CreatePolicyByID(policy *ResponsePolicy) (*ResponsePolicy, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPolicies, policy.General.ID)
+
+	// Wrap the policy with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"policy"`
+		*ResponsePolicy
+	}{
+		ResponsePolicy: policy,
+	}
+
+	var responsePolicy ResponsePolicy
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responsePolicy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responsePolicy, nil
+}

--- a/sdk/jamfpro/classicapi_scripts.go
+++ b/sdk/jamfpro/classicapi_scripts.go
@@ -1,7 +1,7 @@
 // classicapi_scripts.go
-// Jamf Pro Api - Scripts
+// Jamf Pro Classic Api - Scripts
 // api reference: https://developer.jamf.com/jamf-pro/reference/scripts
-// Jamf Pro API requires the structs to support an XML data structure.
+// Jamf Pro Classic Api requires the structs to support an XML data structure.
 
 package jamfpro
 

--- a/sdk/jamfpro/classicapi_usergroups.go
+++ b/sdk/jamfpro/classicapi_usergroups.go
@@ -1,7 +1,7 @@
 // classicapi_usergroups.go
-// Jamf Pro Api - usergroups
+// Jamf Pro Classic Api - usergroups
 // api reference: https://developer.jamf.com/jamf-pro/reference/usergroups
-// Jamf Pro API requires the structs to support an XML data structure.
+// Jamf Pro Classic Api requires the structs to support an XML data structure.
 
 package jamfpro
 

--- a/sdk/jamfpro/classicapi_users.go
+++ b/sdk/jamfpro/classicapi_users.go
@@ -1,7 +1,7 @@
 // classicapi_users.go
-// Jamf Pro Api - users
+// Jamf Pro Classic Api  - users
 // api reference: https://developer.jamf.com/jamf-pro/reference/users
-// Jamf Pro API requires the structs to support an XML data structure.
+// Jamf Pro Classic Api  requires the structs to support an XML data structure.
 
 package jamfpro
 


### PR DESCRIPTION
Added to SDK Jamf Pro Classic API Policies and examples
### Policies - /JSSResource/policies

- [ ] ✅ GET `/JSSResource/policies` - GetPolicies retrieves a list of all policies
- [ ] ✅ GET `/JSSResource/policies/id/{id}` - GetPolicyByID retrieves the details of a policy by its ID
- [ ] ✅ GET `/JSSResource/policies/name/{name}` - GetPolicyByName retrieves a policy by its name
- [ ] ✅ GET `/JSSResource/policies/category/{category}` - GetPolicyByCategory retrieves policies by their category
- [ ] ✅ GET `/JSSResource/policies/createdBy/{createdBy}` - GetPoliciesByType retrieves policies by the type of entity that created them
- [ ] ✅ POST `/JSSResource/policies/id/0` - CreatePolicy creates a new policy
- [ ] ✅ PUT `/JSSResource/policies/id/{id}` - UpdatePolicyByID updates an existing policy by its ID
- [ ] ✅ PUT `/JSSResource/policies/name/{name}` - UpdatePolicyByName updates an existing policy by its name
- [ ] ✅ DELETE `/JSSResource/policies/id/{id}` - DeletePolicyByID deletes a policy by its ID
- [ ] ✅ DELETE `/JSSResource/policies/name/{name}` - DeletePolicyByName deletes a policy by its name