### PR TITLE
Added SDK coverage for Advanced Mobile Device Searches with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,6 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ DELETE `/api/v1/api-roles/{id}` - DeleteJamfApiRoleByID deletes a Jamf API role by its ID.
 - [ ] ✅ DELETE `/api/v1/api-roles` followed by searching by name - DeleteJamfApiRoleByName deletes a Jamf API role by its display name.
 
-
-### Activation Code - /JSSResource/activationcode
-
-- [ ] ✅ GET `/JSSResource/activationcode` - GetActivationCode retrieves the current activation code.
-- [ ] ✅ PUT `/JSSResource/activationcode` - UpdateActivationCode updates the activation code.
-
 ### Jamf Pro Classic API - Advanced Computer Searches
 
 - [ ] ✅ GET `/JSSResource/advancedcomputersearches` - GetAdvancedComputerSearches fetches all advanced computer searches.
@@ -218,6 +212,18 @@ This document tracks the progress of API endpoint coverage tests. As endpoints a
 - [ ] ✅ PUT `/JSSResource/advancedcomputersearches/name/{name}` - UpdateAdvancedComputerSearchByName updates an advanced computer search by its name.
 - [ ] ✅ DELETE `/JSSResource/advancedcomputersearches/id/{id}` - DeleteAdvancedComputerSearchByID deletes an advanced computer search by its ID.
 - [ ] ✅ DELETE `/JSSResource/advancedcomputersearches/name/{name}` - DeleteAdvancedComputerSearchByName deletes an advanced computer search by its name.
+
+### Jamf Pro Classic API - Advanced Mobile Device Searches
+
+- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches` - GetAdvancedMobileDeviceSearches fetches all advanced mobile device searches.
+- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches/id/{id}` - GetAdvancedMobileDeviceSearchByID fetches an advanced mobile device search by its ID.
+- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches/name/{name}` - GetAdvancedMobileDeviceSearchByName fetches advanced mobile device searches by their name.
+- [ ] ✅ POST `/JSSResource/advancedmobiledevicesearches` - CreateAdvancedMobileDeviceSearch creates a new advanced mobile device search.
+- [ ] ✅ PUT `/JSSResource/advancedmobiledevicesearches/id/{id}` - UpdateAdvancedMobileDeviceSearchByID updates an existing advanced mobile device search by its ID.
+- [ ] ✅ PUT `/JSSResource/advancedmobiledevicesearches/name/{name}` - UpdateAdvancedMobileDeviceSearchByName updates an advanced mobile device search by its name.
+- [ ] ✅ DELETE `/JSSResource/advancedmobiledevicesearches/id/{id}` - DeleteAdvancedMobileDeviceSearchByID deletes an advanced mobile device search by its ID.
+- [ ] ✅ DELETE `/JSSResource/advancedmobiledevicesearches/name/{name}` - DeleteAdvancedMobileDeviceSearchByName deletes an advanced mobile device search by its name.
+
 
 ### Jamf Pro Classic API - Advanced User Searches
 

--- a/examples/advanced_computer_searches/CreateAdvancedComputerSearch/CreateAdvancedComputerSearch.go
+++ b/examples/advanced_computer_searches/CreateAdvancedComputerSearch/CreateAdvancedComputerSearch.go
@@ -40,7 +40,7 @@ func main() {
 	newSearch := &jamfpro.ResponseAdvancedComputerSearch{
 		Name:   "Advanced Search Name",
 		ViewAs: "Standard Web Page",
-		Criteria: []jamfpro.Criteria{
+		Criteria: []jamfpro.AdvancedComputerSearchesCriteria{
 			{
 				Criterion: jamfpro.CriterionDetail{
 					Name:         "Last Inventory Update",
@@ -53,14 +53,14 @@ func main() {
 				},
 			},
 		},
-		DisplayFields: []jamfpro.DisplayField{
+		DisplayFields: []jamfpro.AdvancedComputerSearchesDisplayField{
 			{
 				DisplayField: jamfpro.DisplayFieldDetail{
 					Name: "IP Address",
 				},
 			},
 		},
-		Site: jamfpro.SiteDetail{
+		Site: jamfpro.AdvancedComputerSearchesSiteDetail{
 			ID:   -1,
 			Name: "None",
 		},

--- a/examples/advanced_computer_searches/UpdateAdvancedComputerSearchByName/UpdateAdvancedComputerSearchByName.go
+++ b/examples/advanced_computer_searches/UpdateAdvancedComputerSearchByName/UpdateAdvancedComputerSearchByName.go
@@ -38,7 +38,7 @@ func main() {
 	updatedSearch, err := client.UpdateAdvancedComputerSearchByName(advancedComputerSearchName, &jamfpro.ResponseAdvancedComputerSearch{
 		Name:   "Advanced Search Name Updated",
 		ViewAs: "Standard Web Page",
-		Criteria: []jamfpro.Criteria{
+		Criteria: []jamfpro.AdvancedComputerSearchesCriteria{
 			{
 				Size: 1,
 				Criterion: jamfpro.CriterionDetail{
@@ -52,7 +52,7 @@ func main() {
 				},
 			},
 		},
-		DisplayFields: []jamfpro.DisplayField{
+		DisplayFields: []jamfpro.AdvancedComputerSearchesDisplayField{
 			{
 				Size: 1,
 				DisplayField: jamfpro.DisplayFieldDetail{
@@ -60,7 +60,7 @@ func main() {
 				},
 			},
 		},
-		Site: jamfpro.SiteDetail{
+		Site: jamfpro.AdvancedComputerSearchesSiteDetail{
 			ID:   -1,
 			Name: "None",
 		},

--- a/examples/advanced_mobile_searches/CreateAdvancedMobileDeviceSearchByID/CreateAdvancedMobileDeviceSearchByID.go
+++ b/examples/advanced_mobile_searches/CreateAdvancedMobileDeviceSearchByID/CreateAdvancedMobileDeviceSearchByID.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for Jamf Pro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the advanced mobile device search request based on the provided XML
+	search := jamfpro.ResponseAdvancedMobileDeviceSearches{
+		Name:   "Advanced Search Name",
+		ViewAs: "Standard Web Page",
+		Criteria: []jamfpro.AdvancedMobileDeviceSearchesCriteria{
+			{
+				Criterion: jamfpro.Criterion{
+					Name:       "Last Inventory Update",
+					Priority:   0,
+					AndOr:      "and",
+					SearchType: "more than x days ago",
+					Value:      7,
+				},
+			},
+		},
+		DisplayFields: []jamfpro.AdvancedMobileDeviceSearchesDisplayField{
+			{
+				DisplayField: jamfpro.AdvancedMobileDeviceSearchesDisplayFieldItem{
+					Name: "IP Address",
+				},
+			},
+		},
+		Site: jamfpro.AdvancedMobileDeviceSearchesSite{
+			ID:   -1,
+			Name: "None",
+		},
+	}
+
+	// Create the new advanced mobile device search by ID
+	createdSearch, err := client.CreateAdvancedMobileDeviceSearchByID(1, &search)
+	if err != nil {
+		log.Fatalf("Failed to create advanced mobile device search by ID: %v", err)
+	}
+
+	// Convert the created search into pretty XML for printing
+	output, err := xml.MarshalIndent(createdSearch, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling created search to XML: %v", err)
+	}
+
+	// Print the pretty XML
+	fmt.Printf("Created Advanced Mobile Device Search:\n%s\n", string(output))
+}

--- a/examples/advanced_mobile_searches/DeleteAdvancedMobileDeviceSearchByID/DeleteAdvancedMobileDeviceSearchByID.go
+++ b/examples/advanced_mobile_searches/DeleteAdvancedMobileDeviceSearchByID/DeleteAdvancedMobileDeviceSearchByID.go
@@ -1,11 +1,14 @@
 package main
 
 import (
-	"encoding/xml"
-	"fmt"
 	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+const (
+	// Define the ID of the mobile device search you want to delete
+	SearchIDToDelete = 123
 )
 
 func main() {
@@ -33,21 +36,12 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// The ID of the advanced mobile device search you want to retrieve
-	searchID := 5 // Replace with the actual ID you want to retrieve
-
-	// Call the GetAdvancedMobileDeviceSearchByID function
-	search, err := client.GetAdvancedMobileDeviceSearchByID(searchID)
+	// Use the client to delete an advanced mobile device search by ID
+	// Replace 123 with the actual ID
+	err = client.DeleteAdvancedMobileDeviceSearchByID(SearchIDToDelete)
 	if err != nil {
-		log.Fatalf("Error fetching advanced mobile device search by ID: %v", err)
+		log.Fatalf("Error deleting advanced mobile device search by ID: %v", err)
+	} else {
+		log.Printf("Successfully deleted Advanced Mobile Device Search with ID: %d\n", SearchIDToDelete)
 	}
-
-	// Convert the response into pretty XML for printing
-	output, err := xml.MarshalIndent(search, "", "  ")
-	if err != nil {
-		log.Fatalf("Error marshaling search to XML: %v", err)
-	}
-
-	// Print the pretty XML
-	fmt.Printf("Advanced Mobile Device Search (ID: %d):\n%s\n", searchID, string(output))
 }

--- a/examples/advanced_mobile_searches/DeleteAdvancedMobileDeviceSearchByName/DeleteAdvancedMobileDeviceSearchByName.go
+++ b/examples/advanced_mobile_searches/DeleteAdvancedMobileDeviceSearchByName/DeleteAdvancedMobileDeviceSearchByName.go
@@ -1,11 +1,14 @@
 package main
 
 import (
-	"encoding/xml"
-	"fmt"
 	"log"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+const (
+	// Define the name of the mobile device search you want to delete
+	SearchNameToDelete = "Advanced Search Name"
 )
 
 func main() {
@@ -33,21 +36,11 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// The ID of the advanced mobile device search you want to retrieve
-	searchID := 5 // Replace with the actual ID you want to retrieve
-
-	// Call the GetAdvancedMobileDeviceSearchByID function
-	search, err := client.GetAdvancedMobileDeviceSearchByID(searchID)
+	// Use the client to delete an advanced mobile device search by name
+	err = client.DeleteAdvancedMobileDeviceSearchByName(SearchNameToDelete)
 	if err != nil {
-		log.Fatalf("Error fetching advanced mobile device search by ID: %v", err)
+		log.Fatalf("Error deleting advanced mobile device search by name: %v", err)
+	} else {
+		log.Printf("Successfully deleted Advanced Mobile Device Search with name: %s\n", SearchNameToDelete)
 	}
-
-	// Convert the response into pretty XML for printing
-	output, err := xml.MarshalIndent(search, "", "  ")
-	if err != nil {
-		log.Fatalf("Error marshaling search to XML: %v", err)
-	}
-
-	// Print the pretty XML
-	fmt.Printf("Advanced Mobile Device Search (ID: %d):\n%s\n", searchID, string(output))
 }

--- a/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearchByID/GetAdvancedMobileDeviceSearchByID.go
+++ b/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearchByID/GetAdvancedMobileDeviceSearchByID.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/xml"
 	"fmt"
 	"log"
 
@@ -32,40 +33,21 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	updatedSearch, err := client.UpdateAdvancedComputerSearchByID(7, &jamfpro.ResponseAdvancedComputerSearch{
-		Name:   "Advanced Search Name",
-		ViewAs: "Standard Web Page",
-		Criteria: []jamfpro.AdvancedComputerSearchesCriteria{
-			{
-				Size: 1,
-				Criterion: jamfpro.CriterionDetail{
-					Name:         "Last Inventory Update",
-					Priority:     0,
-					AndOr:        "and",
-					SearchType:   "more than x days ago",
-					Value:        "7",
-					OpeningParen: false,
-					ClosingParen: false,
-				},
-			},
-		},
-		DisplayFields: []jamfpro.AdvancedComputerSearchesDisplayField{
-			{
-				Size: 1,
-				DisplayField: jamfpro.DisplayFieldDetail{
-					Name: "IP Address",
-				},
-			},
-		},
-		Site: jamfpro.AdvancedComputerSearchesSiteDetail{
-			ID:   -1,
-			Name: "None",
-		},
-	})
+	// The ID of the advanced mobile device search you want to retrieve
+	searchID := 1 // Replace with the actual ID you want to retrieve
+
+	// Call the GetAdvancedMobileDeviceSearchByID function
+	search, err := client.GetAdvancedMobileDeviceSearchByID(searchID)
 	if err != nil {
-		fmt.Println("Error updating advanced computer search by ID:", err)
-		return
+		log.Fatalf("Error fetching advanced mobile device search by ID: %v", err)
 	}
 
-	fmt.Println("Updated Search:", updatedSearch)
+	// Convert the response into pretty XML for printing
+	output, err := xml.MarshalIndent(search, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling search to XML: %v", err)
+	}
+
+	// Print the pretty XML
+	fmt.Printf("Advanced Mobile Device Search (ID: %d):\n%s\n", searchID, string(output))
 }

--- a/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearchByName/GetAdvancedMobileDeviceSearchByName.go
+++ b/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearchByName/GetAdvancedMobileDeviceSearchByName.go
@@ -33,13 +33,13 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	// The ID of the advanced mobile device search you want to retrieve
-	searchID := 5 // Replace with the actual ID you want to retrieve
+	// The name of the advanced mobile device search you want to retrieve
+	searchName := "Advanced Search Name" // Replace with the actual name you want to retrieve
 
-	// Call the GetAdvancedMobileDeviceSearchByID function
-	search, err := client.GetAdvancedMobileDeviceSearchByID(searchID)
+	// Call the GetAdvancedMobileDeviceSearchByName function
+	search, err := client.GetAdvancedMobileDeviceSearchByName(searchName)
 	if err != nil {
-		log.Fatalf("Error fetching advanced mobile device search by ID: %v", err)
+		log.Fatalf("Error fetching advanced mobile device search by name: %v", err)
 	}
 
 	// Convert the response into pretty XML for printing
@@ -49,5 +49,5 @@ func main() {
 	}
 
 	// Print the pretty XML
-	fmt.Printf("Advanced Mobile Device Search (ID: %d):\n%s\n", searchID, string(output))
+	fmt.Printf("Advanced Mobile Device Search (Name: %s):\n%s\n", searchName, string(output))
 }

--- a/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearches/GetAdvancedMobileDeviceSearches.go
+++ b/examples/advanced_mobile_searches/GetAdvancedMobileDeviceSearches/GetAdvancedMobileDeviceSearches.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/xml"
 	"fmt"
 	"log"
 
@@ -32,40 +33,19 @@ func main() {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
 
-	updatedSearch, err := client.UpdateAdvancedComputerSearchByID(7, &jamfpro.ResponseAdvancedComputerSearch{
-		Name:   "Advanced Search Name",
-		ViewAs: "Standard Web Page",
-		Criteria: []jamfpro.AdvancedComputerSearchesCriteria{
-			{
-				Size: 1,
-				Criterion: jamfpro.CriterionDetail{
-					Name:         "Last Inventory Update",
-					Priority:     0,
-					AndOr:        "and",
-					SearchType:   "more than x days ago",
-					Value:        "7",
-					OpeningParen: false,
-					ClosingParen: false,
-				},
-			},
-		},
-		DisplayFields: []jamfpro.AdvancedComputerSearchesDisplayField{
-			{
-				Size: 1,
-				DisplayField: jamfpro.DisplayFieldDetail{
-					Name: "IP Address",
-				},
-			},
-		},
-		Site: jamfpro.AdvancedComputerSearchesSiteDetail{
-			ID:   -1,
-			Name: "None",
-		},
-	})
+	// Call the GetAdvancedMobileDeviceSearches function
+	searches, err := client.GetAdvancedMobileDeviceSearches()
 	if err != nil {
-		fmt.Println("Error updating advanced computer search by ID:", err)
+		fmt.Println("Error fetching advanced mobile device searches:", err)
 		return
 	}
 
-	fmt.Println("Updated Search:", updatedSearch)
+	// Pretty print the results as XML
+	searchesXML, err := xml.MarshalIndent(searches, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling searches to XML: %v", err)
+	}
+	fmt.Println("Advanced Mobile Device Searches XML:")
+	fmt.Println(string(searchesXML))
+
 }

--- a/examples/advanced_mobile_searches/UpdateAdvancedMobileDeviceSearchByID/UpdateAdvancedMobileDeviceSearchByID.go
+++ b/examples/advanced_mobile_searches/UpdateAdvancedMobileDeviceSearchByID/UpdateAdvancedMobileDeviceSearchByID.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for Jamf Pro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Create a search struct with updated details
+	searchToUpdate := jamfpro.ResponseAdvancedMobileDeviceSearches{
+		Name:   "Advanced Search Name",
+		ViewAs: "Standard Web Page",
+		Criteria: []jamfpro.AdvancedMobileDeviceSearchesCriteria{
+			{
+				Size: 1,
+				Criterion: jamfpro.Criterion{
+					Name:         "Last Inventory Update",
+					Priority:     0,
+					AndOr:        "and",
+					SearchType:   "more than x days ago",
+					Value:        7,
+					OpeningParen: false,
+					ClosingParen: false,
+				},
+			},
+		},
+		DisplayFields: []jamfpro.AdvancedMobileDeviceSearchesDisplayField{
+			{
+				Size: 1,
+				DisplayField: jamfpro.AdvancedMobileDeviceSearchesDisplayFieldItem{
+					Name: "IP Address",
+				},
+			},
+		},
+		Site: jamfpro.AdvancedMobileDeviceSearchesSite{
+			ID:   -1,
+			Name: "None",
+		},
+	}
+
+	// Perform the update
+	updatedSearch, err := client.UpdateAdvancedMobileDeviceSearchByID(123, &searchToUpdate) // Replace 123 with the actual ID
+	if err != nil {
+		log.Fatalf("Error updating advanced mobile device search by ID: %v", err)
+	}
+
+	// Output the updated search
+	output, err := xml.MarshalIndent(updatedSearch, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated search to XML: %v", err)
+	}
+	fmt.Printf("Updated Advanced Mobile Device Search (ID: %d):\n%s\n", 123, string(output))
+}

--- a/examples/advanced_mobile_searches/UpdateAdvancedMobileDeviceSearchByName/UpdateAdvancedMobileDeviceSearchByName.go
+++ b/examples/advanced_mobile_searches/UpdateAdvancedMobileDeviceSearchByName/UpdateAdvancedMobileDeviceSearchByName.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for Jamf Pro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		DebugMode:    true,
+		Logger:       jamfpro.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Create a search struct with updated details
+	searchToUpdate := jamfpro.ResponseAdvancedMobileDeviceSearches{
+		Name:   "Advanced Search Name - Rename",
+		ViewAs: "Standard Web Page",
+		Criteria: []jamfpro.AdvancedMobileDeviceSearchesCriteria{
+			{
+				Size: 1,
+				Criterion: jamfpro.Criterion{
+					Name:         "Last Inventory Update",
+					Priority:     0,
+					AndOr:        "and",
+					SearchType:   "more than x days ago",
+					Value:        7,
+					OpeningParen: false,
+					ClosingParen: false,
+				},
+			},
+		},
+		DisplayFields: []jamfpro.AdvancedMobileDeviceSearchesDisplayField{
+			{
+				Size: 1,
+				DisplayField: jamfpro.AdvancedMobileDeviceSearchesDisplayFieldItem{
+					Name: "IP Address",
+				},
+			},
+		},
+		Site: jamfpro.AdvancedMobileDeviceSearchesSite{
+			ID:   -1,
+			Name: "None",
+		},
+	}
+
+	// Use the struct we created above for the update
+	updatedSearch, err := client.UpdateAdvancedMobileDeviceSearchByName("Advanced Search Name", &searchToUpdate) // Replace with the actual search name
+	if err != nil {
+		log.Fatalf("Error updating advanced mobile device search by name: %v", err)
+	}
+
+	// Output the updated search
+	output, err := xml.MarshalIndent(updatedSearch, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated search to XML: %v", err)
+	}
+	fmt.Printf("Updated Advanced Mobile Device Search (Name: %s):\n%s\n", "Advanced Search Name", string(output))
+}

--- a/examples/computer_groups/CreateSmartComputerGroup/CreateSmartComputerGroup.go
+++ b/examples/computer_groups/CreateSmartComputerGroup/CreateSmartComputerGroup.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Sample data for creating a new computer group (replace with actual data as needed)
 	newSmartGroup := &jamfpro.ResponseComputerGroup{
-		Name:    "Group Name",
+		Name:    "Operating System Version like 15",
 		IsSmart: true,
 		Site: jamfpro.ComputerGroupSite{
 			ID:   -1,
@@ -43,13 +43,13 @@ func main() {
 		},
 		Criteria: []jamfpro.ComputerGroupCriterion{
 			{
-				Name:         "Last Inventory Update",
-				Priority:     0,
-				AndOr:        jamfpro.And,
-				SearchType:   "more than x days ago",
-				SearchValue:  "7",
-				OpeningParen: false,
-				ClosingParen: false,
+				Name:        "Operating System Version",
+				Priority:    0,
+				AndOr:       "and",
+				SearchType:  "like",
+				SearchValue: "macOS 14",
+				//OpeningParen: false,
+				//ClosingParen: false,
 			},
 		},
 	}

--- a/sdk/http_client/jamfpro_api_handler.go
+++ b/sdk/http_client/jamfpro_api_handler.go
@@ -237,7 +237,7 @@ func (h *JamfProApiHandler) MarshalRequest(body interface{}, method string) ([]b
 	// If in debug mode and the method is either POST (Create) or PUT (Update), log the full request body
 	if h.debugMode {
 		h.logger.Debug("Marshaling request for JamfPro API", "method", method)
-		if method == "POST" || method == "PUT" {
+		if method == "POST" || method == "PUT" || method == "Patch" {
 			h.logger.Debug("Full Request Body for JamfPro API:", string(data))
 		}
 	}

--- a/sdk/http_client/jamfpro_api_handler.go
+++ b/sdk/http_client/jamfpro_api_handler.go
@@ -237,7 +237,7 @@ func (h *JamfProApiHandler) MarshalRequest(body interface{}, method string) ([]b
 	// If in debug mode and the method is either POST (Create) or PUT (Update), log the full request body
 	if h.debugMode {
 		h.logger.Debug("Marshaling request for JamfPro API", "method", method)
-		if method == "POST" || method == "PUT" || method == "Patch" {
+		if method == "POST" || method == "PUT" || method == "PATCH" {
 			h.logger.Debug("Full Request Body for JamfPro API:", string(data))
 		}
 	}

--- a/sdk/jamfpro/classicapi_advanced_computer_searches.go
+++ b/sdk/jamfpro/classicapi_advanced_computer_searches.go
@@ -32,14 +32,14 @@ type ResponseAdvancedComputerSearch struct {
 	Sort1         string                                     `xml:"sort_1,omitempty"`
 	Sort2         string                                     `xml:"sort_2,omitempty"`
 	Sort3         string                                     `xml:"sort_3,omitempty"`
-	Criteria      []Criteria                                 `xml:"criteria"`
-	DisplayFields []DisplayField                             `xml:"display_fields"`
+	Criteria      []AdvancedComputerSearchesCriteria         `xml:"criteria"`
+	DisplayFields []AdvancedComputerSearchesDisplayField     `xml:"display_fields"`
 	Computers     []AdvancedComputerSearchDataSubsetComputer `xml:"computers"`
-	Site          SiteDetail                                 `xml:"site"`
+	Site          AdvancedComputerSearchesSiteDetail         `xml:"site"`
 }
 
 // Criteria represents a criterion with its details.
-type Criteria struct {
+type AdvancedComputerSearchesCriteria struct {
 	Size      int             `xml:"size"`
 	Criterion CriterionDetail `xml:"criterion"`
 }
@@ -56,7 +56,7 @@ type CriterionDetail struct {
 }
 
 // DisplayField represents a display field with its details.
-type DisplayField struct {
+type AdvancedComputerSearchesDisplayField struct {
 	Size         int                `xml:"size"`
 	DisplayField DisplayFieldDetail `xml:"display_field"`
 }
@@ -81,7 +81,7 @@ type ComputerDetail struct {
 }
 
 // SiteDetail represents the details of a site.
-type SiteDetail struct {
+type AdvancedComputerSearchesSiteDetail struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }

--- a/sdk/jamfpro/classicapi_advanced_mobile_searches.go
+++ b/sdk/jamfpro/classicapi_advanced_mobile_searches.go
@@ -6,6 +6,7 @@
 package jamfpro
 
 import (
+	"encoding/xml"
 	"fmt"
 )
 
@@ -25,64 +26,64 @@ type AdvancedMobileDeviceSearchDetail struct {
 
 // ResponseAdvancedMobileDeviceSearches represents the structure of the response for an advanced mobile device search.
 type ResponseAdvancedMobileDeviceSearches struct {
-	ID            int                                        `json:"id"`             // Unique identifier for the search
-	Name          string                                     `json:"name"`           // Name of the search
-	ViewAs        string                                     `json:"view_as"`        // The format in which the search results are viewed
-	Sort1         string                                     `json:"sort_1"`         // First sorting criteria
-	Sort2         string                                     `json:"sort_2"`         // Second sorting criteria
-	Sort3         string                                     `json:"sort_3"`         // Third sorting criteria
-	Criteria      []AdvancedMobileDeviceSearchesCriteria     `json:"criteria"`       // List of search criteria
-	DisplayFields []AdvancedMobileDeviceSearchesDisplayField `json:"display_fields"` // Fields to display in search results
-	MobileDevices []AdvancedMobileDeviceSearchesMobileDevice `json:"mobile_devices"` // List of mobile devices that match the search
-	Site          AdvancedMobileDeviceSearchesSite           `json:"site"`           // Information about the site associated with the search
+	ID            int                                        `xml:"id"`                       // Unique identifier for the search
+	Name          string                                     `xml:"name"`                     // Name of the search
+	ViewAs        string                                     `xml:"view_as,omitempty"`        // The format in which the search results are viewed
+	Sort1         string                                     `xml:"sort_1,omitempty"`         // First sorting criteria
+	Sort2         string                                     `xml:"sort_2,omitempty"`         // Second sorting criteria
+	Sort3         string                                     `xml:"sort_3,omitempty"`         // Third sorting criteria
+	Criteria      []AdvancedMobileDeviceSearchesCriteria     `xml:"criteria,omitempty"`       // List of search criteria
+	DisplayFields []AdvancedMobileDeviceSearchesDisplayField `xml:"display_fields,omitempty"` // Fields to display in search results
+	MobileDevices []AdvancedMobileDeviceSearchesMobileDevice `xml:"mobile_devices,omitempty"` // List of mobile devices that match the search
+	Site          AdvancedMobileDeviceSearchesSite           `xml:"site,omitempty"`           // Information about the site associated with the search
 }
 
 // CriteriaDetail represents a single search criterion.
 type AdvancedMobileDeviceSearchesCriteria struct {
-	Size      int       `json:"size"`      // Number of criteria
-	Criterion Criterion `json:"criterion"` // Detailed criterion
+	Size      int       `xml:"size"`      // Number of criteria
+	Criterion Criterion `xml:"criterion"` // Detailed criterion
 }
 
 // Criterion contains the details of a single criterion in the search.
 type Criterion struct {
-	Name         string `json:"name"`          // Name of the criterion
-	Priority     int    `json:"priority"`      // Priority of the criterion
-	AndOr        string `json:"and_or"`        // Logical operator to combine criteria
-	SearchType   string `json:"search_type"`   // Type of search being performed
-	Value        int    `json:"value"`         // Value for the criterion
-	OpeningParen bool   `json:"opening_paren"` // Indicates if there is an opening parenthesis for grouping
-	ClosingParen bool   `json:"closing_paren"` // Indicates if there is a closing parenthesis for grouping
+	Name         string `xml:"name"`                    // Name of the criterion
+	Priority     int    `xml:"priority"`                // Priority of the criterion
+	AndOr        string `xml:"and_or"`                  // Logical operator to combine criteria
+	SearchType   string `xml:"search_type"`             // Type of search being performed
+	Value        int    `xml:"value"`                   // Value for the criterion
+	OpeningParen bool   `xml:"opening_paren,omitempty"` // Indicates if there is an opening parenthesis for grouping
+	ClosingParen bool   `xml:"closing_paren,omitempty"` // Indicates if there is a closing parenthesis for grouping
 }
 
 // DisplayFieldDetailWrapper wraps a display field with its size.
 type AdvancedMobileDeviceSearchesDisplayField struct {
-	Size         int                                          `json:"size"`          // Number of display fields
-	DisplayField AdvancedMobileDeviceSearchesDisplayFieldItem `json:"display_field"` // Detailed display field
+	Size         int                                          `xml:"size"`          // Number of display fields
+	DisplayField AdvancedMobileDeviceSearchesDisplayFieldItem `xml:"display_field"` // Detailed display field
 }
 
 // DisplayField represents a field to display in the search results.
 type AdvancedMobileDeviceSearchesDisplayFieldItem struct {
-	Name string `json:"name"` // Name of the display field
+	Name string `xml:"name"` // Name of the display field
 }
 
 // MobileDeviceDetailWrapper wraps a mobile device with its size.
 type AdvancedMobileDeviceSearchesMobileDevice struct {
-	Size         int              `json:"size"`          // Number of mobile devices
-	MobileDevice MobileDeviceItem `json:"mobile_device"` // Detailed mobile device
+	Size         int              `xml:"size"`          // Number of mobile devices
+	MobileDevice MobileDeviceItem `xml:"mobile_device"` // Detailed mobile device
 }
 
 // MobileDevice contains details about a single mobile device.
 type MobileDeviceItem struct {
-	ID          int    `json:"id"`           // Unique identifier for the mobile device
-	Name        string `json:"name"`         // Name of the mobile device
-	UDID        string `json:"udid"`         // Unique Device Identifier for the mobile device
-	DisplayName string `json:"Display_Name"` // Display name of the mobile device
+	ID          int    `xml:"id"`           // Unique identifier for the mobile device
+	Name        string `xml:"name"`         // Name of the mobile device
+	UDID        string `xml:"udid"`         // Unique Device Identifier for the mobile device
+	DisplayName string `xml:"Display_Name"` // Display name of the mobile device
 }
 
 // SiteDetail represents the details of a site associated with the search.
 type AdvancedMobileDeviceSearchesSite struct {
-	ID   int    `json:"id"`   // Unique identifier for the site
-	Name string `json:"name"` // Name of the site
+	ID   int    `xml:"id"`   // Unique identifier for the site
+	Name string `xml:"name"` // Name of the site
 }
 
 // GetAdvancedMobileDeviceSearches retrieves all advanced mobile device searches.
@@ -117,4 +118,134 @@ func (c *Client) GetAdvancedMobileDeviceSearchByID(id int) (*ResponseAdvancedMob
 	}
 
 	return &searchDetail, nil
+}
+
+// GetAdvancedMobileDeviceSearchByName retrieves an advanced mobile device search by its name.
+func (c *Client) GetAdvancedMobileDeviceSearchByName(name string) (*ResponseAdvancedMobileDeviceSearches, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriAPIAdvancedMobileDeviceSearches, name)
+
+	var searchDetail ResponseAdvancedMobileDeviceSearches
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &searchDetail)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch advanced mobile device search by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &searchDetail, nil
+}
+
+// CreateAdvancedMobileDeviceSearchByID creates a new advanced mobile device search with the given ID.
+func (c *Client) CreateAdvancedMobileDeviceSearchByID(id int, search *ResponseAdvancedMobileDeviceSearches) (*ResponseAdvancedMobileDeviceSearches, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriAPIAdvancedMobileDeviceSearches, id)
+
+	// Check if the Site field in the search struct is not provided and set default values if needed
+	if search.Site.ID == 0 && search.Site.Name == "" {
+		search.Site = AdvancedMobileDeviceSearchesSite{
+			ID:   -1,
+			Name: "None",
+		}
+	}
+
+	// Wrap the search request with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"advanced_mobile_device_search"`
+		*ResponseAdvancedMobileDeviceSearches
+	}{
+		ResponseAdvancedMobileDeviceSearches: search,
+	}
+
+	var createdSearch ResponseAdvancedMobileDeviceSearches
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &createdSearch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create advanced mobile device search by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &createdSearch, nil
+}
+
+// UpdateAdvancedMobileDeviceSearchByID updates an existing advanced mobile device search by its ID.
+func (c *Client) UpdateAdvancedMobileDeviceSearchByID(id int, search *ResponseAdvancedMobileDeviceSearches) (*ResponseAdvancedMobileDeviceSearches, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriAPIAdvancedMobileDeviceSearches, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"advanced_mobile_device_search"`
+		*ResponseAdvancedMobileDeviceSearches
+	}{
+		ResponseAdvancedMobileDeviceSearches: search,
+	}
+
+	var updatedSearch ResponseAdvancedMobileDeviceSearches
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedSearch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update advanced mobile device search by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedSearch, nil
+}
+
+// UpdateAdvancedMobileDeviceSearchByName updates an existing advanced mobile device search by its name.
+func (c *Client) UpdateAdvancedMobileDeviceSearchByName(name string, search *ResponseAdvancedMobileDeviceSearches) (*ResponseAdvancedMobileDeviceSearches, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriAPIAdvancedMobileDeviceSearches, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"advanced_mobile_device_search"`
+		*ResponseAdvancedMobileDeviceSearches
+	}{
+		ResponseAdvancedMobileDeviceSearches: search,
+	}
+
+	var updatedSearch ResponseAdvancedMobileDeviceSearches
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedSearch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update advanced mobile device search by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedSearch, nil
+}
+
+// DeleteAdvancedMobileDeviceSearchByID deletes an existing advanced mobile device search by its ID.
+func (c *Client) DeleteAdvancedMobileDeviceSearchByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriAPIAdvancedMobileDeviceSearches, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete advanced mobile device search by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteAdvancedMobileDeviceSearchByName deletes an existing advanced mobile device search by its name.
+func (c *Client) DeleteAdvancedMobileDeviceSearchByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriAPIAdvancedMobileDeviceSearches, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete advanced mobile device search by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
 }

--- a/sdk/jamfpro/classicapi_advanced_mobile_searches.go
+++ b/sdk/jamfpro/classicapi_advanced_mobile_searches.go
@@ -1,0 +1,120 @@
+// classicapi_advanced_mobile_searches.go
+// Jamf Pro Classic Api - Advanced Mobile Searches
+// api reference: https://developer.jamf.com/jamf-pro/reference/advancedmobiledevicesearches
+// Classic API requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"fmt"
+)
+
+const uriAPIAdvancedMobileDeviceSearches = "/JSSResource/advancedmobiledevicesearches"
+
+// ResponseAdvancedMobileDeviceSearchesList represents the structure for multiple advanced mobile device searches.
+type ResponseAdvancedMobileDeviceSearchesList struct {
+	Size                         int                                `xml:"size"`
+	AdvancedMobileDeviceSearches []AdvancedMobileDeviceSearchDetail `xml:"advanced_mobile_device_search"`
+}
+
+// AdvancedMobileDeviceSearchDetail represents the details of an advanced mobile device search.
+type AdvancedMobileDeviceSearchDetail struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// ResponseAdvancedMobileDeviceSearches represents the structure of the response for an advanced mobile device search.
+type ResponseAdvancedMobileDeviceSearches struct {
+	ID            int                                        `json:"id"`             // Unique identifier for the search
+	Name          string                                     `json:"name"`           // Name of the search
+	ViewAs        string                                     `json:"view_as"`        // The format in which the search results are viewed
+	Sort1         string                                     `json:"sort_1"`         // First sorting criteria
+	Sort2         string                                     `json:"sort_2"`         // Second sorting criteria
+	Sort3         string                                     `json:"sort_3"`         // Third sorting criteria
+	Criteria      []AdvancedMobileDeviceSearchesCriteria     `json:"criteria"`       // List of search criteria
+	DisplayFields []AdvancedMobileDeviceSearchesDisplayField `json:"display_fields"` // Fields to display in search results
+	MobileDevices []AdvancedMobileDeviceSearchesMobileDevice `json:"mobile_devices"` // List of mobile devices that match the search
+	Site          AdvancedMobileDeviceSearchesSite           `json:"site"`           // Information about the site associated with the search
+}
+
+// CriteriaDetail represents a single search criterion.
+type AdvancedMobileDeviceSearchesCriteria struct {
+	Size      int       `json:"size"`      // Number of criteria
+	Criterion Criterion `json:"criterion"` // Detailed criterion
+}
+
+// Criterion contains the details of a single criterion in the search.
+type Criterion struct {
+	Name         string `json:"name"`          // Name of the criterion
+	Priority     int    `json:"priority"`      // Priority of the criterion
+	AndOr        string `json:"and_or"`        // Logical operator to combine criteria
+	SearchType   string `json:"search_type"`   // Type of search being performed
+	Value        int    `json:"value"`         // Value for the criterion
+	OpeningParen bool   `json:"opening_paren"` // Indicates if there is an opening parenthesis for grouping
+	ClosingParen bool   `json:"closing_paren"` // Indicates if there is a closing parenthesis for grouping
+}
+
+// DisplayFieldDetailWrapper wraps a display field with its size.
+type AdvancedMobileDeviceSearchesDisplayField struct {
+	Size         int                                          `json:"size"`          // Number of display fields
+	DisplayField AdvancedMobileDeviceSearchesDisplayFieldItem `json:"display_field"` // Detailed display field
+}
+
+// DisplayField represents a field to display in the search results.
+type AdvancedMobileDeviceSearchesDisplayFieldItem struct {
+	Name string `json:"name"` // Name of the display field
+}
+
+// MobileDeviceDetailWrapper wraps a mobile device with its size.
+type AdvancedMobileDeviceSearchesMobileDevice struct {
+	Size         int              `json:"size"`          // Number of mobile devices
+	MobileDevice MobileDeviceItem `json:"mobile_device"` // Detailed mobile device
+}
+
+// MobileDevice contains details about a single mobile device.
+type MobileDeviceItem struct {
+	ID          int    `json:"id"`           // Unique identifier for the mobile device
+	Name        string `json:"name"`         // Name of the mobile device
+	UDID        string `json:"udid"`         // Unique Device Identifier for the mobile device
+	DisplayName string `json:"Display_Name"` // Display name of the mobile device
+}
+
+// SiteDetail represents the details of a site associated with the search.
+type AdvancedMobileDeviceSearchesSite struct {
+	ID   int    `json:"id"`   // Unique identifier for the site
+	Name string `json:"name"` // Name of the site
+}
+
+// GetAdvancedMobileDeviceSearches retrieves all advanced mobile device searches.
+func (c *Client) GetAdvancedMobileDeviceSearches() (*ResponseAdvancedMobileDeviceSearchesList, error) {
+	endpoint := uriAPIAdvancedMobileDeviceSearches
+
+	var searchesList ResponseAdvancedMobileDeviceSearchesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &searchesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch advanced mobile device searches: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &searchesList, nil
+}
+
+// GetAdvancedMobileDeviceSearchByID retrieves an advanced mobile device search by its ID.
+func (c *Client) GetAdvancedMobileDeviceSearchByID(id int) (*ResponseAdvancedMobileDeviceSearches, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriAPIAdvancedMobileDeviceSearches, id)
+
+	var searchDetail ResponseAdvancedMobileDeviceSearches
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &searchDetail)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch advanced mobile device search by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &searchDetail, nil
+}


### PR DESCRIPTION
added with examples

### Jamf Pro Classic API - Advanced Mobile Device Searches

- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches` - GetAdvancedMobileDeviceSearches fetches all advanced mobile device searches.
- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches/id/{id}` - GetAdvancedMobileDeviceSearchByID fetches an advanced mobile device search by its ID.
- [ ] ✅ GET `/JSSResource/advancedmobiledevicesearches/name/{name}` - GetAdvancedMobileDeviceSearchByName fetches advanced mobile device searches by their name.
- [ ] ✅ POST `/JSSResource/advancedmobiledevicesearches` - CreateAdvancedMobileDeviceSearch creates a new advanced mobile device search.
- [ ] ✅ PUT `/JSSResource/advancedmobiledevicesearches/id/{id}` - UpdateAdvancedMobileDeviceSearchByID updates an existing advanced mobile device search by its ID.
- [ ] ✅ PUT `/JSSResource/advancedmobiledevicesearches/name/{name}` - UpdateAdvancedMobileDeviceSearchByName updates an advanced mobile device search by its name.
- [ ] ✅ DELETE `/JSSResource/advancedmobiledevicesearches/id/{id}` - DeleteAdvancedMobileDeviceSearchByID deletes an advanced mobile device search by its ID.
- [ ] ✅ DELETE `/JSSResource/advancedmobiledevicesearches/name/{name}` - DeleteAdvancedMobileDeviceSearchByName deletes an advanced mobile device search by its name.