### PR TITLE
+ sdk coverage for classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,37 @@ This documentation covers the API endpoints available for retrieving information
 - [x] ✅ **GET** `/api/v2/jamf-pro-information`  
   `GetJamfProInformation` retrieves information about various services enabled on the Jamf Pro server, like VPP token, DEP account status, BYOD, and more.
 
+	
+# Jamf Pro Classic API - Classes
+
+This documentation provides details on the API endpoints available for managing classes within Jamf Pro using the Classic API which requires XML data structure support.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/classes`  
+  `GetClasses` retrieves a list of all classes.
+
+- [x] ✅ **GET** `/JSSResource/classes/id/{id}`  
+  `GetClassesByID` fetches a single class by its ID.
+
+- [x] ✅ **GET** `/JSSResource/classes/name/{name}`  
+  `GetClassesByName` retrieves a class by its name.
+
+- [x] ✅ **POST** `/JSSResource/classes/id/0`  
+  `CreateClassesByID` creates a new class with the provided details. Using ID `0` indicates creation as per API pattern. If `siteId` is not included, it defaults to `siteId: "-1"`.
+
+- [x] ✅ **PUT** `/JSSResource/classes/id/{id}`  
+  `UpdateClassesByID` updates an existing class with the given ID.
+
+- [x] ✅ **PUT** `/JSSResource/classes/name/{name}`  
+  `UpdateClassesByName` updates an existing class with the given name.
+
+- [x] ✅ **DELETE** `/JSSResource/classes/id/{id}`  
+  `DeleteClassByID` deletes a class by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/classes/name/{name}`  
+  `DeleteClassByName` deletes a class by its name.
+
 
 ## Progress Summary
 

--- a/examples/classes/DeleteClassByID/DeleteClassByID.go
+++ b/examples/classes/DeleteClassByID/DeleteClassByID.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the Jamf Pro API client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro API client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// The ID of the class you want to delete
+	classIDToDelete := 123 // Replace with the actual ID
+
+	// Call the delete function with the class ID
+	err = client.DeleteClassByID(classIDToDelete)
+	if err != nil {
+		log.Fatalf("Error deleting class by ID: %v", err)
+	} else {
+		fmt.Printf("Class with ID %d deleted successfully.\n", classIDToDelete)
+	}
+
+}

--- a/examples/classes/DeleteClassByName/DeleteClassByName.go
+++ b/examples/classes/DeleteClassByName/DeleteClassByName.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the Jamf Pro API client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro API client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// The name of the class you want to delete
+	classNameToDelete := "Math 101" // Replace with the actual class name
+
+	// Call the delete function with the class name
+	err = client.DeleteClassByName(classNameToDelete)
+	if err != nil {
+		log.Fatalf("Error deleting class by name: %v", err)
+	} else {
+		fmt.Printf("Class with name %s deleted successfully.\n", classNameToDelete)
+	}
+}

--- a/examples/classes/UpdateClassesByID/UpdateClassesByID.go
+++ b/examples/classes/UpdateClassesByID/UpdateClassesByID.go
@@ -37,46 +37,37 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create Jamf Pro client: %v", err)
 	}
-
-	// Define the new class details
-	newClass := &jamfpro.ResponseClasses{
+	// Define the class details you want to update.
+	classToUpdate := &jamfpro.ResponseClasses{
+		ID:          1, // The ID of the class you want to update.
 		Source:      "N/A",
 		Name:        "Math 101",
-		Description: "Introduction to basic mathematics",
+		Description: "Introduction to advanced algebra",
 		Site: jamfpro.ClassSite{
 			ID:   -1,
 			Name: "None",
 		},
-		MeetingTimes: jamfpro.ClassMeetingTimes{
-			MeetingTime: jamfpro.ClassMeetingTime{
-				Days:      "M W F",
-				StartTime: 1300,
-				EndTime:   1345,
-			},
+		Teachers: []jamfpro.ClassTeacher{
+			{Teacher: "John Doe"},
+			{Teacher: "Jane Smith"},
 		},
-		MobileDeviceGroup: jamfpro.ClassDeviceGroup{
-			ID:   3,
-			Name: "All Managed iPod touches",
-		},
-		MobileDeviceGroupID: []jamfpro.ClassGroupID{
-			{
-				ID: 3,
-			},
-		},
-		TeacherIDs: []jamfpro.ClassTeacherID{
-			{ID: 1},
-			{ID: 2},
-		},
-		// Do not include TeacherIDs if Teachers is set
+		// ... include other fields as necessary ...
 	}
 
-	// Create class
-	createdClass, err := client.CreateClassesByID(newClass)
+	// Call the update function with the class ID and the new details.
+	err = client.UpdateClassesByID(classToUpdate.ID, classToUpdate)
 	if err != nil {
-		log.Fatalf("Error creating class: %s\n", err)
+		log.Fatalf("Error updating class: %v", err)
+	} else {
+		fmt.Println("Class updated successfully.")
 	}
 
-	// Print the XML structure of the created class for verification
-	classXML, _ := xml.MarshalIndent(createdClass, "", "  ")
-	fmt.Printf("Created Class:\n%s\n", classXML)
+	// If you need to check the updated details, perform a GetClassByID call here and print or log the results.
+	// For example:
+	updatedClass, err := client.GetClassesByID(classToUpdate.ID)
+	if err != nil {
+		log.Fatalf("Error retrieving updated class: %v", err)
+	}
+	classXML, _ := xml.MarshalIndent(updatedClass, "", "  ")
+	fmt.Printf("Updated Class Details:\n%s\n", classXML)
 }

--- a/examples/classes/UpdateClassesByName/UpdateClassesByName.go
+++ b/examples/classes/UpdateClassesByName/UpdateClassesByName.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the Jamf Pro API client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new Jamf Pro API client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the class details you want to update by its name.
+	classToUpdate := &jamfpro.ResponseClasses{
+		Name:        "Math 101", // The name of the class you want to update.
+		Description: "Introduction to advanced algebra",
+		Site: jamfpro.ClassSite{
+			ID:   -1,
+			Name: "None",
+		},
+		Teachers: []jamfpro.ClassTeacher{
+			{Teacher: "John Doe"},
+			{Teacher: "Jane Smith"},
+		},
+		TeacherIDs: []jamfpro.ClassTeacherID{
+			{ID: 123}, // Assume 123 is the ID of John Doe
+			{ID: 456}, // Assume 456 is the ID of Jane Smith
+		},
+		// ... include other fields as necessary ...
+	}
+
+	// Call the update function with the class name and the new details.
+	err = client.UpdateClassesByName(classToUpdate.Name, classToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating class by name: %v", err)
+	} else {
+		fmt.Println("Class updated successfully by name.")
+	}
+
+	// If you need to check the updated details, perform a GetClassesByName call here and print or log the results.
+	// For example:
+	updatedClass, err := client.GetClassesByName(classToUpdate.Name)
+	if err != nil {
+		log.Fatalf("Error retrieving updated class by name: %v", err)
+	}
+	classXML, err := xml.MarshalIndent(updatedClass, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshalling updated class to XML: %v", err)
+	}
+	fmt.Printf("Updated Class Details by Name:\n%s\n", classXML)
+}

--- a/sdk/http_client/sdk_version.go
+++ b/sdk/http_client/sdk_version.go
@@ -4,7 +4,7 @@ package http_client
 import "fmt"
 
 const (
-	SDKVersion    = "0.0.54"
+	SDKVersion    = "0.0.55"
 	UserAgentBase = "go-jamfpro-api-sdk"
 )
 

--- a/sdk/jamfpro/classicapi_classes.go
+++ b/sdk/jamfpro/classicapi_classes.go
@@ -28,71 +28,70 @@ type ClassItem struct {
 
 // Structs for the Class response by ID
 type ResponseClasses struct {
-	ID                  int                 `xml:"id"`
-	Source              string              `xml:"source"`
-	Name                string              `xml:"name"`
-	Description         string              `xml:"description"`
+	ID                  int                 `xml:"id,omitempty"`
+	Source              string              `xml:"source,omitempty"`
+	Name                string              `xml:"name"` // Required
+	Description         string              `xml:"description,omitempty"`
 	Site                ClassSite           `xml:"site"`
-	MobileDeviceGroup   ClassDeviceGroup    `xml:"mobile_device_group"`
-	Students            []ClassStudent      `xml:"students>student"`
-	Teachers            []ClassTeacher      `xml:"teachers>teacher"`
-	TeacherIDs          []ClassTeacherID    `xml:"teacher_ids>id"`
-	StudentGroupIDs     []ClassGroupID      `xml:"student_group_ids>id"`
-	TeacherGroupIDs     []ClassGroupID      `xml:"teacher_group_ids>id"`
-	MobileDevices       []ClassMobileDevice `xml:"mobile_devices>mobile_device"`
-	MobileDeviceGroupID []ClassGroupID      `xml:"mobile_device_group_id>id"`
-	MeetingTimes        ClassMeetingTimes   `xml:"meeting_times"`
-	AppleTVs            []ClassAppleTV      `xml:"apple_tvs>apple_tv"`
+	MobileDeviceGroup   ClassDeviceGroup    `xml:"mobile_device_group,omitempty"`
+	Students            []ClassStudent      `xml:"students>student,omitempty"`
+	Teachers            []ClassTeacher      `xml:"teachers>teacher,omitempty"`
+	TeacherIDs          []ClassTeacherID    `xml:"teacher_ids>id,omitempty"`
+	StudentGroupIDs     []ClassGroupID      `xml:"student_group_ids>id,omitempty"`
+	TeacherGroupIDs     []ClassGroupID      `xml:"teacher_group_ids>id,omitempty"`
+	MobileDevices       []ClassMobileDevice `xml:"mobile_devices>mobile_device,omitempty"`
+	MobileDeviceGroupID []ClassGroupID      `xml:"mobile_device_group_id>id,omitempty"`
+	MeetingTimes        ClassMeetingTimes   `xml:"meeting_times,omitempty"`
+	AppleTVs            []ClassAppleTV      `xml:"apple_tvs>apple_tv,omitempty"`
 }
-
 type ClassSite struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name"` // Required
 }
 
 type ClassDeviceGroup struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
 }
 
 type ClassStudent struct {
-	Student string `xml:"student"`
+	Student string `xml:"student,omitempty"`
 }
 
 type ClassTeacher struct {
-	Teacher string `xml:"teacher"`
+	Teacher string `xml:"teacher,omitempty"`
 }
 
 type ClassTeacherID struct {
-	ID int `xml:"id"`
+	ID int `xml:"id,omitempty"`
 }
 
 type ClassGroupID struct {
-	ID int `xml:"id"`
+	ID int `xml:"id,omitempty"`
 }
 
 type ClassMobileDevice struct {
-	Name           string `xml:"name"`
-	UDID           string `xml:"udid"`
-	WifiMacAddress string `xml:"wifi_mac_address"`
+	Name           string `xml:"name,omitempty"`
+	UDID           string `xml:"udid,omitempty"`
+	WifiMacAddress string `xml:"wifi_mac_address,omitempty"`
 }
 
 type ClassMeetingTimes struct {
-	MeetingTime ClassMeetingTime `xml:"meeting_time"`
+	MeetingTime ClassMeetingTime `xml:"meeting_time,omitempty"`
 }
 
 type ClassMeetingTime struct {
-	Days      string `xml:"days"`
-	StartTime int    `xml:"start_time"`
-	EndTime   int    `xml:"end_time"`
+	Days      string `xml:"days,omitempty"`
+	StartTime int    `xml:"start_time,omitempty"`
+	EndTime   int    `xml:"end_time,omitempty"`
 }
 
 type ClassAppleTV struct {
-	Name            string `xml:"name"`
-	UDID            string `xml:"udid"`
-	WifiMacAddress  string `xml:"wifi_mac_address"`
-	DeviceID        string `xml:"device_id"`
-	AirplayPassword string `xml:"airplay_password"`
+	Name            string `xml:"name,omitempty"`
+	UDID            string `xml:"udid,omitempty"`
+	WifiMacAddress  string `xml:"wifi_mac_address,omitempty"`
+	DeviceID        string `xml:"device_id,omitempty"`
+	AirplayPassword string `xml:"airplay_password,omitempty"`
 }
 
 // GetClasses gets a list of all classes.


### PR DESCRIPTION
# Jamf Pro Classic API - Classes

This documentation provides details on the API endpoints available for managing classes within Jamf Pro using the Classic API which requires XML data structure support.

## Endpoints

- [x] ✅ **GET** `/JSSResource/classes`  
  `GetClasses` retrieves a list of all classes.

- [x] ✅ **GET** `/JSSResource/classes/id/{id}`  
  `GetClassesByID` fetches a single class by its ID.

- [x] ✅ **GET** `/JSSResource/classes/name/{name}`  
  `GetClassesByName` retrieves a class by its name.

- [x] ✅ **POST** `/JSSResource/classes/id/0`  
  `CreateClassesByID` creates a new class with the provided details. Using ID `0` indicates creation as per API pattern. If `siteId` is not included, it defaults to `siteId: "-1"`.

- [x] ✅ **PUT** `/JSSResource/classes/id/{id}`  
  `UpdateClassesByID` updates an existing class with the given ID.

- [x] ✅ **PUT** `/JSSResource/classes/name/{name}`  
  `UpdateClassesByName` updates an existing class with the given name.

- [x] ✅ **DELETE** `/JSSResource/classes/id/{id}`  
  `DeleteClassByID` deletes a class by its ID.

- [x] ✅ **DELETE** `/JSSResource/classes/name/{name}`  
  `DeleteClassByName` deletes a class by its name.
