### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,11 +557,42 @@ This documentation provides details on the API endpoints available for managing 
 - [x] ✅ **DELETE** `/JSSResource/diskencryptionconfigurations/name/{name}`  
   `DeleteDiskEncryptionConfigurationByName` deletes a disk encryption configuration by its name.
 
+### Jamf Pro Classic API - Distribution Points
+
+This documentation provides details on the API endpoints available for managing distribution points within Jamf Pro using the Classic API, which requires XML data structure support.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/distributionpoints`  
+  `GetDistributionPoints` retrieves a serialized list of all distribution points.
+
+- [x] ✅ **GET** `/JSSResource/distributionpoints/id/{id}`  
+  `GetDistributionPointByID` fetches a single distribution point by its ID.
+
+- [x] ✅ **GET** `/JSSResource/distributionpoints/name/{name}`  
+  `GetDistributionPointByName` retrieves a distribution point by its name.
+
+- [x] ✅ **POST** `/JSSResource/distributionpoints/id/0`  
+  `CreateDistributionPoint` creates a new distribution point with the provided details. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/distributionpoints/id/{id}`  
+  `UpdateDistributionPointByID` updates an existing distribution point by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/distributionpoints/name/{name}`  
+  `UpdateDistributionPointByName` updates an existing distribution point by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/distributionpoints/id/{id}`  
+  `DeleteDistributionPointByID` deletes a distribution point by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/distributionpoints/name/{name}`  
+  `DeleteDistributionPointByName` deletes a distribution point by its name.
+
+
 
 ## Progress Summary
 
-- Total Endpoints: 185
-- Covered: 182
+- Total Endpoints: 193
+- Covered: 190
 - Not Covered: 3
 - Partially Covered: 0
 

--- a/examples/distribution_points/CreateDistributionPoint/CreateDistributionPoint.go
+++ b/examples/distribution_points/CreateDistributionPoint/CreateDistributionPoint.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// New distribution point to create
+	newDistributionPoint := jamfpro.ResponseDistributionPoint{
+		Name:                     "New York Share",
+		IPAddress:                "ny.company.com",
+		IsMaster:                 true,
+		EnableLoadBalancing:      false,
+		SSHUsername:              "casperadmin",
+		Password:                 "password",
+		ConnectionType:           "SMB",
+		ShareName:                "Caspershare",
+		WorkgroupOrDomain:        "COMPANY",
+		SharePort:                139,
+		ReadOnlyUsername:         "casperinstall",
+		ReadOnlyPassword:         "password",
+		ReadWriteUsername:        "casperwrite",
+		ReadWritePassword:        "password",
+		HTTPDownloadsEnabled:     true,
+		HTTPURL:                  "http://ny.company.com/CasperShare",
+		Context:                  "CasperShare",
+		Protocol:                 "http",
+		Port:                     80,
+		NoAuthenticationRequired: false,
+		UsernamePasswordRequired: true,
+		HTTPUsername:             "casperinstall",
+		HTTPPassword:             "password",
+	}
+
+	// Call CreateDistributionPoint function
+	createdDistributionPoint, err := client.CreateDistributionPoint(&newDistributionPoint)
+	if err != nil {
+		log.Fatalf("Error creating distribution point: %v", err)
+	}
+
+	// Pretty print the newly created distribution point in XML
+	createdDistributionPointXML, err := xml.MarshalIndent(createdDistributionPoint, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling created distribution point data: %v", err)
+	}
+	fmt.Println("Created Distribution Point:\n", string(createdDistributionPointXML))
+}

--- a/examples/distribution_points/DeleteDistributionPointByID/DeleteDistributionPointByID.go
+++ b/examples/distribution_points/DeleteDistributionPointByID/DeleteDistributionPointByID.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// ID of the distribution point to delete
+	distributionPointID := 1 // Replace with the actual ID
+
+	// Call DeleteDistributionPointByID function
+	err = client.DeleteDistributionPointByID(distributionPointID)
+	if err != nil {
+		log.Fatalf("Error deleting distribution point: %v", err)
+	}
+
+	fmt.Println("Distribution Point deleted successfully")
+}

--- a/examples/distribution_points/DeleteDistributionPointByName/DeleteDistributionPointByName.go
+++ b/examples/distribution_points/DeleteDistributionPointByName/DeleteDistributionPointByName.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Name of the distribution point to delete
+	distributionPointName := "New York Share" // Replace with the actual name
+
+	// Call DeleteDistributionPointByName function
+	err = client.DeleteDistributionPointByName(distributionPointName)
+	if err != nil {
+		log.Fatalf("Error deleting distribution point by name '%s': %v", distributionPointName, err)
+	}
+
+	fmt.Printf("Distribution Point '%s' deleted successfully\n", distributionPointName)
+}

--- a/examples/distribution_points/GetDistributionPointByID/GetDistributionPointByID.go
+++ b/examples/distribution_points/GetDistributionPointByID/GetDistributionPointByID.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// ID of the distribution point to fetch
+	distributionPointID := 1 // Replace with actual ID
+
+	// Call GetDistributionPointByID function
+	distributionPoint, err := client.GetDistributionPointByID(distributionPointID)
+	if err != nil {
+		log.Fatalf("Error fetching distribution point: %v", err)
+	}
+
+	// Pretty print the distribution point in XML
+	distributionPointXML, err := xml.MarshalIndent(distributionPoint, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling distribution point data: %v", err)
+	}
+	fmt.Println("Fetched Distribution Point:\n", string(distributionPointXML))
+}

--- a/examples/distribution_points/GetDistributionPointByName/GetDistributionPointByName.go
+++ b/examples/distribution_points/GetDistributionPointByName/GetDistributionPointByName.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Name of the distribution point to fetch
+	distributionPointName := "New York Share" // Replace with the actual name
+
+	// Call GetDistributionPointByName function
+	distributionPoint, err := client.GetDistributionPointByName(distributionPointName)
+	if err != nil {
+		log.Fatalf("Error fetching distribution point: %v", err)
+	}
+
+	// Pretty print the distribution point in XML
+	distributionPointXML, err := xml.MarshalIndent(distributionPoint, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling distribution point data: %v", err)
+	}
+	fmt.Println("Fetched Distribution Point:\n", string(distributionPointXML))
+}

--- a/examples/distribution_points/GetDistributionPoints/GetDistributionPoints.go
+++ b/examples/distribution_points/GetDistributionPoints/GetDistributionPoints.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Call GetDistributionPoints function
+	distributionPoints, err := client.GetDistributionPoints()
+	if err != nil {
+		log.Fatalf("Error fetching distribution points: %v", err)
+	}
+
+	// Pretty print the distribution points in XML
+	distributionPointsXML, err := xml.MarshalIndent(distributionPoints, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling distribution points data: %v", err)
+	}
+	fmt.Println("Fetched Distribution Points:\n", string(distributionPointsXML))
+}

--- a/examples/distribution_points/UpdateDistributionPointByID/UpdateDistributionPointByID.go
+++ b/examples/distribution_points/UpdateDistributionPointByID/UpdateDistributionPointByID.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// New distribution point to create
+	updateDistributionPoint := jamfpro.ResponseDistributionPoint{
+		Name:                     "Tokyo Share",
+		IPAddress:                "tokyo.company.com",
+		IsMaster:                 true,
+		EnableLoadBalancing:      false,
+		SSHUsername:              "casperadmin",
+		Password:                 "password",
+		ConnectionType:           "SMB",
+		ShareName:                "Caspershare",
+		WorkgroupOrDomain:        "COMPANY",
+		SharePort:                139,
+		ReadOnlyUsername:         "casperinstall",
+		ReadOnlyPassword:         "password",
+		ReadWriteUsername:        "casperwrite",
+		ReadWritePassword:        "password",
+		HTTPDownloadsEnabled:     true,
+		HTTPURL:                  "http://ny.company.com/CasperShare",
+		Context:                  "CasperShare",
+		Protocol:                 "http",
+		Port:                     80,
+		NoAuthenticationRequired: false,
+		UsernamePasswordRequired: true,
+		HTTPUsername:             "casperinstall",
+		HTTPPassword:             "password",
+	}
+
+	// ID of the distribution point to update
+	distributionPointID := 1 // Replace with the actual ID
+
+	// Call UpdateDistributionPointByID function
+	updatedDistributionPoint, err := client.UpdateDistributionPointByID(distributionPointID, &updateDistributionPoint)
+	if err != nil {
+		log.Fatalf("Error updating distribution point: %v", err)
+	}
+
+	// Pretty print the updated distribution point in XML
+	updatedDistributionPointXML, err := xml.MarshalIndent(updatedDistributionPoint, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated distribution point data: %v", err)
+	}
+	fmt.Println("Updated Distribution Point:\n", string(updatedDistributionPointXML))
+}

--- a/examples/distribution_points/UpdateDistributionPointByName/UpdateDistributionPointByName.go
+++ b/examples/distribution_points/UpdateDistributionPointByName/UpdateDistributionPointByName.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// New distribution point to create
+	updateDistributionPoint := jamfpro.ResponseDistributionPoint{
+		Name:                     "New York Share",
+		IPAddress:                "ny.company.com",
+		IsMaster:                 true,
+		EnableLoadBalancing:      false,
+		SSHUsername:              "casperadmin",
+		Password:                 "password",
+		ConnectionType:           "SMB",
+		ShareName:                "Caspershare",
+		WorkgroupOrDomain:        "COMPANY",
+		SharePort:                139,
+		ReadOnlyUsername:         "casperinstall",
+		ReadOnlyPassword:         "password",
+		ReadWriteUsername:        "casperwrite",
+		ReadWritePassword:        "password",
+		HTTPDownloadsEnabled:     true,
+		HTTPURL:                  "http://ny.company.com/CasperShare",
+		Context:                  "CasperShare",
+		Protocol:                 "http",
+		Port:                     80,
+		NoAuthenticationRequired: false,
+		UsernamePasswordRequired: true,
+		HTTPUsername:             "casperinstall",
+		HTTPPassword:             "password",
+	}
+
+	// Name of the distribution point to update
+	distributionPointName := "Tokyo Share" // Replace with the actual name
+
+	// Call UpdateDistributionPointByName function
+	updatedDistributionPoint, err := client.UpdateDistributionPointByName(distributionPointName, &updateDistributionPoint)
+	if err != nil {
+		log.Fatalf("Error updating distribution point: %v", err)
+	}
+
+	// Pretty print the updated distribution point in XML
+	updatedDistributionPointXML, err := xml.MarshalIndent(updatedDistributionPoint, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated distribution point data: %v", err)
+	}
+	fmt.Println("Updated Distribution Point:\n", string(updatedDistributionPointXML))
+}

--- a/sdk/jamfpro/classicapi_distribution_points.go
+++ b/sdk/jamfpro/classicapi_distribution_points.go
@@ -1,0 +1,212 @@
+// classicapi_distribution_points.go
+// Jamf Pro Classic Api - Distribution Points
+// api reference: https://developer.jamf.com/jamf-pro/reference/distributionpoints
+// Classic API requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// URI for Distribution Points in Jamf Pro API
+const uriDistributionPoints = "/JSSResource/distributionpoints"
+
+// Struct to capture the XML response for distribution points list
+type ResponseDistributionPointsList struct {
+	Size              int                         `xml:"size"`
+	DistributionPoint DistributionPointListDetail `xml:"distribution_point"`
+}
+
+type DistributionPointListDetail struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// Struct for detailed Distribution Point data
+type ResponseDistributionPoint struct {
+	ID                       int    `xml:"id"`
+	Name                     string `xml:"name"`
+	IPAddress                string `xml:"ip_address"`
+	IsMaster                 bool   `xml:"is_master"`
+	FailoverPoint            string `xml:"failover_point"`
+	FailoverPointURL         string `xml:"failover_point_url"`
+	EnableLoadBalancing      bool   `xml:"enable_load_balancing"`
+	LocalPath                string `xml:"local_path"`
+	SSHUsername              string `xml:"ssh_username"`
+	Password                 string `xml:"password"`
+	ConnectionType           string `xml:"connection_type"`
+	ShareName                string `xml:"share_name"`
+	WorkgroupOrDomain        string `xml:"workgroup_or_domain"`
+	SharePort                int    `xml:"share_port"`
+	ReadOnlyUsername         string `xml:"read_only_username"`
+	ReadOnlyPassword         string `xml:"read_only_password"`
+	ReadWriteUsername        string `xml:"read_write_username"`
+	ReadWritePassword        string `xml:"read_write_password"`
+	HTTPDownloadsEnabled     bool   `xml:"http_downloads_enabled"`
+	HTTPURL                  string `xml:"http_url"`
+	Context                  string `xml:"context"`
+	Protocol                 string `xml:"protocol"`
+	Port                     int    `xml:"port"`
+	NoAuthenticationRequired bool   `xml:"no_authentication_required"`
+	UsernamePasswordRequired bool   `xml:"username_password_required"`
+	HTTPUsername             string `xml:"http_username"`
+	HTTPPassword             string `xml:"http_password"`
+}
+
+// GetDistributionPoints retrieves a serialized list of distribution points.
+func (c *Client) GetDistributionPoints() (*ResponseDistributionPointsList, error) {
+	endpoint := uriDistributionPoints
+
+	var distributionPoints ResponseDistributionPointsList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &distributionPoints)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Distribution Points: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &distributionPoints, nil
+}
+
+// GetDistributionPointByID retrieves a single distribution point by its ID.
+func (c *Client) GetDistributionPointByID(id int) (*ResponseDistributionPoint, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriDistributionPoints, id)
+
+	var distributionPoint ResponseDistributionPoint
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &distributionPoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Distribution Point by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &distributionPoint, nil
+}
+
+// GetDistributionPointByName retrieves a single distribution point by its name.
+func (c *Client) GetDistributionPointByName(name string) (*ResponseDistributionPoint, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriDistributionPoints, name)
+
+	var distributionPoint ResponseDistributionPoint
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &distributionPoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Distribution Point by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &distributionPoint, nil
+}
+
+// CreateDistributionPoint creates a new distribution point.
+func (c *Client) CreateDistributionPoint(dp *ResponseDistributionPoint) (*ResponseDistributionPoint, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriDistributionPoints)
+
+	// Wrap the distribution point with the XML root element name
+	requestBody := struct {
+		XMLName xml.Name `xml:"distribution_point"`
+		*ResponseDistributionPoint
+	}{
+		ResponseDistributionPoint: dp,
+	}
+
+	var createdDistributionPoint ResponseDistributionPoint
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &createdDistributionPoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Distribution Point: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &createdDistributionPoint, nil
+}
+
+// UpdateDistributionPointByID updates a distribution point by its ID.
+func (c *Client) UpdateDistributionPointByID(id int, dp *ResponseDistributionPoint) (*ResponseDistributionPoint, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriDistributionPoints, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"distribution_point"`
+		*ResponseDistributionPoint
+	}{
+		ResponseDistributionPoint: dp,
+	}
+
+	var updatedDistributionPoint ResponseDistributionPoint
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedDistributionPoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Distribution Point by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedDistributionPoint, nil
+}
+
+// UpdateDistributionPointByName updates a distribution point by its name.
+func (c *Client) UpdateDistributionPointByName(name string, dp *ResponseDistributionPoint) (*ResponseDistributionPoint, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriDistributionPoints, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"distribution_point"`
+		*ResponseDistributionPoint
+	}{
+		ResponseDistributionPoint: dp,
+	}
+
+	var updatedDistributionPoint ResponseDistributionPoint
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedDistributionPoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Distribution Point by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedDistributionPoint, nil
+}
+
+// DeleteDistributionPointByID deletes a distribution point by its ID.
+func (c *Client) DeleteDistributionPointByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriDistributionPoints, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete Distribution Point by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteDistributionPointByName deletes a distribution point by its name.
+func (c *Client) DeleteDistributionPointByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriDistributionPoints, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete Distribution Point by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
added sdk coverage for Distribution Points with examples

### Jamf Pro Classic API - Distribution Points

This documentation provides details on the API endpoints available for managing distribution points within Jamf Pro using the Classic API, which requires XML data structure support.

## Endpoints

- [x] ✅ **GET** `/JSSResource/distributionpoints`  
  `GetDistributionPoints` retrieves a serialized list of all distribution points.

- [x] ✅ **GET** `/JSSResource/distributionpoints/id/{id}`  
  `GetDistributionPointByID` fetches a single distribution point by its ID.

- [x] ✅ **GET** `/JSSResource/distributionpoints/name/{name}`  
  `GetDistributionPointByName` retrieves a distribution point by its name.

- [x] ✅ **POST** `/JSSResource/distributionpoints/id/0`  
  `CreateDistributionPoint` creates a new distribution point with the provided details. The ID `0` in the endpoint indicates creation.

- [x] ✅ **PUT** `/JSSResource/distributionpoints/id/{id}`  
  `UpdateDistributionPointByID` updates an existing distribution point by its ID.

- [x] ✅ **PUT** `/JSSResource/distributionpoints/name/{name}`  
  `UpdateDistributionPointByName` updates an existing distribution point by its name.

- [x] ✅ **DELETE** `/JSSResource/distributionpoints/id/{id}`  
  `DeleteDistributionPointByID` deletes a distribution point by its ID.

- [x] ✅ **DELETE** `/JSSResource/distributionpoints/name/{name}`  
  `DeleteDistributionPointByName` deletes a distribution point by its name.
