### PR TITLE
+ ebooks sdk coverage with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,11 +677,44 @@ This documentation provides details on the API endpoints available for managing 
 - [x] ✅ **DELETE** `/JSSResource/dockitems/name/{name}`
   `DeleteDockItemsByName` deletes a dock item by its name.
 
+### Jamf Pro Classic API - eBooks
+
+This documentation provides details on the API endpoints available for managing dock items within Jamf Pro using the Classic API, which requires XML data structure support.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/ebooks`
+  `GetEbooks` retrieves a serialized list of all ebooks.
+
+- [x] ✅ **GET** `/JSSResource/ebooks/id/{id}`
+  `GetEbooksByID` fetches a single ebook by its ID.
+
+- [x] ✅ **GET** `/JSSResource/ebooks/name/{name}`
+  `GetEbooksByName` retrieves an ebook by its name.
+
+- [x] ✅ **GET** `/JSSResource/ebooks/name/{name}/subset/{subset}`
+  `GetEbooksByNameAndDataSubset` retrieves a specific subset (General, Scope, or SelfService) of an ebook by its name.
+
+- [x] ✅ **POST** `/JSSResource/ebooks/id/0`
+  `CreateEbook` creates a new ebook with the provided details. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/ebooks/id/{id}`
+  `UpdateEbookByID` updates an existing ebook by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/ebooks/name/{name}`
+  `UpdateEbookByName` updates an existing ebook by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/ebooks/id/{id}`
+  `DeleteEbookByID` deletes an ebook by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/ebooks/name/{name}`
+  `DeleteEbookByName` deletes an ebook by its name.
+
 
 ## Progress Summary
 
-- Total Endpoints: 235
-- Covered: 216
+- Total Endpoints: 244
+- Covered: 225
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/examples/ebooks/CreateEbook/CreateEbook.go
+++ b/examples/ebooks/CreateEbook/CreateEbook.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the ebook to be created
+	newEbook := jamfpro.ResponseEbooks{
+		General: jamfpro.EbooksDataSubsetGeneral{
+			Name:            "iPhone User Guide for iOS 10.3",
+			Author:          "Apple Inc.",
+			Version:         "1",
+			Free:            true,
+			URL:             "https://itunes.apple.com/us/book/iphone-user-guide-for-ios-10-3/id1134772174?mt=11&amp;uo=4",
+			DeploymentType:  "Install Automatically/Prompt Users to Install",
+			FileType:        "PDF",
+			DeployAsManaged: true,
+			Category:        jamfpro.EbooksDataSubsetCategory{ID: -1, Name: "Unknown"},
+			Site:            jamfpro.EbooksDataSubsetSite{ID: -1, Name: "None"},
+		},
+		// Add Scope and SelfService if needed
+	}
+
+	// Call CreateEbook function
+	createdEbook, err := client.CreateEbook(newEbook)
+	if err != nil {
+		log.Fatalf("Error creating ebook: %v", err)
+	}
+
+	// Pretty print the created ebook in XML
+	ebookXML, err := xml.MarshalIndent(createdEbook, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling ebook data: %v", err)
+	}
+	fmt.Println("Created Ebook:\n", string(ebookXML))
+}

--- a/examples/ebooks/DeleteEbookByID/DeleteEbookByID.go
+++ b/examples/ebooks/DeleteEbookByID/DeleteEbookByID.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	ebookID := 1 // Replace with the actual eBook ID
+
+	err = client.DeleteEbookByID(ebookID)
+	if err != nil {
+		log.Fatalf("Error deleting ebook by ID: %v", err)
+	}
+
+	fmt.Println("Ebook successfully deleted by ID")
+}

--- a/examples/ebooks/DeleteEbookByName/DeleteEbookByName.go
+++ b/examples/ebooks/DeleteEbookByName/DeleteEbookByName.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	// Configuration for the jamfpro client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	ebookName := "iPhone User Guide for iOS 10.3" // Replace with the actual eBook name
+
+	err = client.DeleteEbookByName(ebookName)
+	if err != nil {
+		log.Fatalf("Error deleting ebook by Name: %v", err)
+	}
+
+	fmt.Println("Ebook successfully deleted by Name")
+}

--- a/examples/ebooks/GetEbooks/GetEbooks.go
+++ b/examples/ebooks/GetEbooks/GetEbooks.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file for OAuth credentials
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Configuration for the jamfpro client
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     http_client.LogLevelDebug,
+		Logger:       http_client.NewDefaultLogger(),
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Call the GetEbooks function
+	ebooks, err := client.GetEbooks()
+	if err != nil {
+		log.Fatalf("Error fetching eBooks: %v", err)
+	}
+
+	// Output the fetched eBooks
+	fmt.Printf("Fetched eBooks: %+v\n", ebooks)
+}

--- a/examples/ebooks/GetEbooksByID/GetEbooksByID.go
+++ b/examples/ebooks/GetEbooksByID/GetEbooksByID.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the department ID you want to retrieve
+	eBooksID := 1 // Replace with the desired department ID
+
+	// Call GetEbooksByID function
+	ebook, err := client.GetEbooksByID(eBooksID)
+	if err != nil {
+		log.Fatalf("Error fetching department by ID: %v", err)
+	}
+
+	// Pretty print the department in XML
+	ebookXML, err := xml.MarshalIndent(ebook, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling ebooks data: %v", err)
+	}
+	fmt.Println("Fetched Ebook:\n", string(ebookXML))
+}

--- a/examples/ebooks/GetEbooksByName/GetEbooksByName.go
+++ b/examples/ebooks/GetEbooksByName/GetEbooksByName.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the name of the ebook you want to retrieve
+	ebookName := "iPhone User Guide for iOS 10.3" // Replace with the desired ebook name
+
+	// Call GetEbooksByName function
+	ebook, err := client.GetEbooksByName(ebookName)
+	if err != nil {
+		log.Fatalf("Error fetching ebook by name: %v", err)
+	}
+
+	// Pretty print the ebook in XML
+	ebookXML, err := xml.MarshalIndent(ebook, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling ebook data: %v", err)
+	}
+	fmt.Println("Fetched Ebook:\n", string(ebookXML))
+}

--- a/examples/ebooks/GetEbooksByNameAndDataSubset/GetEbooksByNameAndDataSubset.go
+++ b/examples/ebooks/GetEbooksByNameAndDataSubset/GetEbooksByNameAndDataSubset.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	ebookName := "iPhone User Guide for iOS 10.3" // Replace with the desired ebook name
+	subset := "General"                           // Replace with "General", "Scope", or "SelfService"
+
+	ebook, err := client.GetEbooksByNameAndDataSubset(ebookName, subset)
+	if err != nil {
+		log.Fatalf("Error fetching ebook by Name and Subset: %v", err)
+	}
+
+	ebookXML, err := xml.MarshalIndent(ebook, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling ebook data: %v", err)
+	}
+	fmt.Println("Fetched Ebook Subset:\n", string(ebookXML))
+}

--- a/examples/ebooks/UpdateEbookByID/UpdateEbookByID.go
+++ b/examples/ebooks/UpdateEbookByID/UpdateEbookByID.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the ebook to be created
+	ebookID := 1 // Replace with the actual eBook ID
+	ebookToUpdate := jamfpro.ResponseEbooks{
+		General: jamfpro.EbooksDataSubsetGeneral{
+			Name:            "iPhone User Guide for iOS 10.3",
+			Author:          "Apple Inc.",
+			Version:         "1",
+			Free:            true,
+			URL:             "https://itunes.apple.com/us/book/iphone-user-guide-for-ios-10-3/id1134772174?mt=11&amp;uo=4",
+			DeploymentType:  "Install Automatically/Prompt Users to Install",
+			FileType:        "PDF",
+			DeployAsManaged: true,
+			Category:        jamfpro.EbooksDataSubsetCategory{ID: -1, Name: "Unknown"},
+			Site:            jamfpro.EbooksDataSubsetSite{ID: -1, Name: "None"},
+		},
+		// Add Scope and SelfService if needed
+	}
+
+	updatedEbook, err := client.UpdateEbookByID(ebookID, ebookToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating ebook by ID: %v", err)
+	}
+
+	ebookXML, err := xml.MarshalIndent(updatedEbook, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated ebook data: %v", err)
+	}
+	fmt.Println("Updated Ebook by ID:\n", string(ebookXML))
+}

--- a/examples/ebooks/UpdateEbookByName/UpdateEbookByName.go
+++ b/examples/ebooks/UpdateEbookByName/UpdateEbookByName.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug
+
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	ebookName := "iPhone User Guide for iOS 10.3" // Replace with the actual eBook name
+	ebookToUpdate := jamfpro.ResponseEbooks{
+		General: jamfpro.EbooksDataSubsetGeneral{
+			Name:            "iPhone User Guide for iOS 16",
+			Author:          "Apple Inc.",
+			Version:         "1",
+			Free:            true,
+			URL:             "https://books.apple.com/gb/book/iphone-user-guide/id6443146864",
+			DeploymentType:  "Install Automatically/Prompt Users to Install",
+			FileType:        "PDF",
+			DeployAsManaged: true,
+			Category:        jamfpro.EbooksDataSubsetCategory{ID: -1, Name: "Unknown"},
+			Site:            jamfpro.EbooksDataSubsetSite{ID: -1, Name: "None"},
+		},
+		// Add Scope and SelfService if needed
+	}
+
+	updatedEbook, err := client.UpdateEbookByName(ebookName, ebookToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating ebook by Name: %v", err)
+	}
+
+	ebookXML, err := xml.MarshalIndent(updatedEbook, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated ebook data: %v", err)
+	}
+	fmt.Println("Updated Ebook by Name:\n", string(ebookXML))
+}

--- a/sdk/http_client/sdk_version.go
+++ b/sdk/http_client/sdk_version.go
@@ -4,7 +4,7 @@ package http_client
 import "fmt"
 
 const (
-	SDKVersion    = "0.0.62"
+	SDKVersion    = "0.0.63"
 	UserAgentBase = "go-jamfpro-api-sdk"
 )
 

--- a/sdk/jamfpro/classicapi_ebooks.go
+++ b/sdk/jamfpro/classicapi_ebooks.go
@@ -1,0 +1,368 @@
+// classicapi_ebooks.go
+// Jamf Pro Classic Api - Ebooks
+// api reference: https://developer.jamf.com/jamf-pro/reference/ebooks
+// Classic API requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// URI for Ebooks in Jamf Pro API
+const uriEbooks = "/JSSResource/ebooks"
+
+// Struct to capture the XML response for ebooks list
+type ResponseEbooksList struct {
+	Size  int   `xml:"size"`
+	Ebook Ebook `xml:"ebook"`
+}
+
+type Ebook struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// ResponseEbooks represents the detailed structure of an Ebook response.
+type ResponseEbooks struct {
+	General     EbooksDataSubsetGeneral     `xml:"general"`
+	Scope       EbooksDataSubsetScope       `xml:"scope"`
+	SelfService EbooksDataSubsetSelfService `xml:"self_service"`
+}
+
+type EbooksDataSubsetGeneral struct {
+	ID              int                             `xml:"id"`
+	Name            string                          `xml:"name"`
+	Author          string                          `xml:"author"`
+	Version         string                          `xml:"version"`
+	Free            bool                            `xml:"free"`
+	URL             string                          `xml:"url"`
+	DeploymentType  string                          `xml:"deployment_type"`
+	FileType        string                          `xml:"file_type"`
+	DeployAsManaged bool                            `xml:"deploy_as_managed"`
+	Category        EbooksDataSubsetCategory        `xml:"category"`
+	SelfServiceIcon EbooksDataSubsetSelfServiceIcon `xml:"self_service_icon"`
+	Site            EbooksDataSubsetSite            `xml:"site"`
+}
+
+type EbooksDataSubsetCategory struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type EbooksDataSubsetSelfServiceIcon struct {
+	ID   int    `xml:"id"`
+	URI  string `xml:"uri"`
+	Data string `xml:"data"`
+}
+
+type EbooksDataSubsetSite struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type EbooksDataSubsetScope struct {
+	AllComputers       bool                            `xml:"all_computers"`
+	AllMobileDevices   bool                            `xml:"all_mobile_devices"`
+	AllJSSUsers        bool                            `xml:"all_jss_users"`
+	Computers          []EbooksDataSubsetComputer      `xml:"computers>computer"`
+	ComputerGroups     []EbooksDataSubsetComputerGroup `xml:"computer_groups>computer_group"`
+	MobileDevices      []EbooksDataSubsetMobileDevice  `xml:"mobile_devices>mobile_device"`
+	MobileDeviceGroups []MobileDeviceGroup             `xml:"mobile_device_groups>mobile_device_group"`
+	Buildings          []EbooksDataSubsetBuilding      `xml:"buildings>building"`
+	Departments        []EbooksDataSubsetDepartment    `xml:"departments>department"`
+	JSSUsers           []EbooksDataSubsetUser          `xml:"jss_users>user"`
+	JSSUserGroups      []EbooksDataSubsetUserGroup     `xml:"jss_user_groups>user_group"`
+	Classes            []EbooksDataSubsetClass         `xml:"classes>class"`
+	Limitations        EbooksDataSubsetLimitations     `xml:"limitations"`
+	Exclusions         EbooksDataSubsetExclusions      `xml:"exclusions"`
+}
+
+// Computer represents a single computer within the scope.
+type EbooksDataSubsetComputer struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+	UDID string `xml:"udid"`
+}
+
+// ComputerGroup represents a group of computers within the scope.
+type EbooksDataSubsetComputerGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// MobileDevice represents a single mobile device within the scope.
+type EbooksDataSubsetMobileDevice struct {
+	ID             int    `xml:"id"`
+	Name           string `xml:"name"`
+	UDID           string `xml:"udid"`
+	WiFiMacAddress string `xml:"wifi_mac_address"`
+}
+
+// MobileDeviceGroup represents a group of mobile devices within the scope.
+type MobileDeviceGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// Building represents a building within the scope.
+type EbooksDataSubsetBuilding struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// Department represents a department within the scope.
+type EbooksDataSubsetDepartment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// User represents a user within the scope.
+type EbooksDataSubsetUser struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// UserGroup represents a group of users within the scope.
+type EbooksDataSubsetUserGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// Class represents a class within the scope.
+type EbooksDataSubsetClass struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// Exclusions represent any exclusions within the scope.
+type EbooksDataSubsetExclusions struct {
+	Computers          []EbooksDataSubsetComputer          `xml:"computers>computer"`
+	ComputerGroups     []EbooksDataSubsetComputerGroup     `xml:"computer_groups>computer_group"`
+	MobileDevices      []EbooksDataSubsetMobileDevice      `xml:"mobile_devices>mobile_device"`
+	MobileDeviceGroups []EbooksDataSubsetMobileDeviceGroup `xml:"mobile_device_groups>mobile_device_group"`
+	Buildings          []EbooksDataSubsetBuilding          `xml:"buildings>building"`
+	Departments        []EbooksDataSubsetDepartment        `xml:"departments>department"`
+	JSSUsers           []EbooksDataSubsetUser              `xml:"jss_users>user"`
+	JSSUserGroups      []EbooksDataSubsetUserGroup         `xml:"jss_user_groups>user_group"`
+}
+
+// SelfServiceCategories represent the categories within SelfService.
+type EbooksDataSubsetSelfServiceCategories struct {
+	Category []EbooksDataSubsetCategory `xml:"category"`
+}
+
+type EbooksDataSubsetSelfService struct {
+	SelfServiceDisplayName      string                                `xml:"self_service_display_name"`
+	InstallButtonText           string                                `xml:"install_button_text"`
+	SelfServiceDescription      string                                `xml:"self_service_description"`
+	ForceUsersToViewDescription bool                                  `xml:"force_users_to_view_description"`
+	SelfServiceIcon             EbooksDataSubsetSelfServiceIcon       `xml:"self_service_icon"`
+	FeatureOnMainPage           bool                                  `xml:"feature_on_main_page"`
+	SelfServiceCategories       EbooksDataSubsetSelfServiceCategories `xml:"self_service_categories"`
+	Notification                bool                                  `xml:"notification"`
+	NotificationSubject         string                                `xml:"notification_subject"`
+	NotificationMessage         string                                `xml:"notification_message"`
+}
+
+// EbooksDataSubsetMobileDeviceGroup represents a group of mobile devices within the scope.
+type EbooksDataSubsetMobileDeviceGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// EbooksDataSubsetNetworkSegment represents a network segment within the limitations.
+type EbooksDataSubsetNetworkSegment struct {
+	ID   int    `xml:"id"`
+	UID  string `xml:"uid,omitempty"`
+	Name string `xml:"name"`
+}
+
+// EbooksDataSubsetLimitations represents any limitations within the scope.
+type EbooksDataSubsetLimitations struct {
+	NetworkSegments []EbooksDataSubsetNetworkSegment `xml:"network_segments>network_segment"`
+	Users           []EbooksDataSubsetUser           `xml:"users>user"`
+	UserGroups      []EbooksDataSubsetUserGroup      `xml:"user_groups>user_group"`
+}
+
+// GetEbooks retrieves a serialized list of ebooks.
+func (c *Client) GetEbooks() (*ResponseEbooksList, error) {
+	endpoint := uriEbooks
+
+	var ebooks ResponseEbooksList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &ebooks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Ebooks: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &ebooks, nil
+}
+
+// GetEbooksByID retrieves a single ebook by its ID.
+func (c *Client) GetEbooksByID(id int) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriEbooks, id)
+
+	var ebook ResponseEbooks
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &ebook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Ebook by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &ebook, nil
+}
+
+// GetEbooksByName retrieves a single ebook by its name.
+func (c *Client) GetEbooksByName(name string) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriEbooks, name)
+
+	var ebook ResponseEbooks
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &ebook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Ebook by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &ebook, nil
+}
+
+// GetEbooksByNameAndDataSubset retrieves a specific subset of an ebook by its name.
+func (c *Client) GetEbooksByNameAndDataSubset(name, subset string) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/name/%s/subset/%s", uriEbooks, name, subset)
+
+	var ebook ResponseEbooks
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &ebook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Ebook by Name and Subset: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &ebook, nil
+}
+
+// CreateEbook creates a new ebook.
+func (c *Client) CreateEbook(ebook ResponseEbooks) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriEbooks) // '0' typically used for creation in APIs
+
+	// Handle default values, especially for the Site ID if not provided
+	if ebook.General.Site.ID == 0 && ebook.General.Site.Name == "" {
+		ebook.General.Site = EbooksDataSubsetSite{
+			ID:   -1,
+			Name: "None",
+		}
+	}
+
+	// The requestBody struct should mirror the ResponseEbooks struct, including all nested structs
+	requestBody := struct {
+		XMLName xml.Name `xml:"ebook"`
+		ResponseEbooks
+	}{
+		ResponseEbooks: ebook,
+	}
+
+	var response ResponseEbooks
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ebook: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &response, nil
+}
+
+// UpdateEbookByID updates an existing ebook by its ID.
+func (c *Client) UpdateEbookByID(id int, ebook ResponseEbooks) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriEbooks, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"ebook"`
+		ResponseEbooks
+	}{
+		ResponseEbooks: ebook,
+	}
+
+	var updatedEbook ResponseEbooks
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedEbook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Ebook by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedEbook, nil
+}
+
+// UpdateEbookByName updates an existing ebook by its name.
+func (c *Client) UpdateEbookByName(name string, ebook ResponseEbooks) (*ResponseEbooks, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriEbooks, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"ebook"`
+		ResponseEbooks
+	}{
+		ResponseEbooks: ebook,
+	}
+
+	var updatedEbook ResponseEbooks
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedEbook)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Ebook by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedEbook, nil
+}
+
+// DeleteEbookByID deletes a ebook by its ID.
+func (c *Client) DeleteEbookByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriEbooks, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete Ebook Item by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteEbookByName deletes a ebook by its name.
+func (c *Client) DeleteEbookByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriEbooks, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete Ebook Item by Name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added SDK coverage with examples for ebooks for the jamf pro classic api

- [x] ✅ **GET** `/JSSResource/ebooks`
  `GetEbooks` retrieves a serialized list of all ebooks.

- [x] ✅ **GET** `/JSSResource/ebooks/id/{id}`
  `GetEbooksByID` fetches a single ebook by its ID.

- [x] ✅ **GET** `/JSSResource/ebooks/name/{name}`
  `GetEbooksByName` retrieves an ebook by its name.

- [x] ✅ **GET** `/JSSResource/ebooks/name/{name}/subset/{subset}`
  `GetEbooksByNameAndDataSubset` retrieves a specific subset (General, Scope, or SelfService) of an ebook by its name.

- [x] ✅ **POST** `/JSSResource/ebooks/id/0`
  `CreateEbook` creates a new ebook with the provided details. The ID `0` in the endpoint indicates creation.

- [x] ✅ **PUT** `/JSSResource/ebooks/id/{id}`
  `UpdateEbookByID` updates an existing ebook by its ID.

- [x] ✅ **PUT** `/JSSResource/ebooks/name/{name}`
  `UpdateEbookByName` updates an existing ebook by its name.

- [x] ✅ **DELETE** `/JSSResource/ebooks/id/{id}`
  `DeleteEbookByID` deletes an ebook by its ID.

- [x] ✅ **DELETE** `/JSSResource/ebooks/name/{name}`
  `DeleteEbookByName` deletes an ebook by its name.