### PR TITLE
+ sdk coverage fo mobile device enrollment profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,11 +975,56 @@ This documentation outlines the API endpoints available for managing Mobile Exte
 - [x] ✅ **DELETE** `/JSSResource/mobiledeviceextensionattributes/name/{name}`
   `DeleteMobileExtensionAttributeByName` deletes a Mobile Extension Attribute by its name.
 
+### Jamf Pro Classic API - Mobile Device Enrollment Profiles
+
+This documentation outlines the API endpoints available for managing Mobile Device Enrollment Profiles within Jamf Pro using the Classic API, which supports XML data structures.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles`
+  `GetMobileDeviceEnrollmentProfiles` retrieves a serialized list of all Mobile Device Enrollment Profiles.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
+  `GetMobileDeviceEnrollmentProfileByID` fetches details of a single Mobile Device Enrollment Profile by its ID.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
+  `GetMobileDeviceEnrollmentProfileByName` retrieves details of a Mobile Device Enrollment Profile by its name.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
+  `GetProfileByInvitation` fetches a Mobile Device Enrollment Profile by its invitation.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}/subset/{subset}`
+  `GetMobileDeviceEnrollmentProfileByIDBySubset` fetches a specific Mobile Device Enrollment Profile by its ID and a specified subset.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}/subset/{subset}`
+  `GetMobileDeviceEnrollmentProfileByNameBySubset` fetches a specific Mobile Device Enrollment Profile by its name and a specified subset.
+
+- [x] ✅ **POST** `/JSSResource/mobiledeviceenrollmentprofiles/id/0`
+  `CreateMobileDeviceEnrollmentProfile` creates a new Mobile Device Enrollment Profile. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
+  `UpdateMobileDeviceEnrollmentProfileByID` updates an existing Mobile Device Enrollment Profile by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
+  `UpdateMobileDeviceEnrollmentProfileByName` updates an existing Mobile Device Enrollment Profile by its name.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
+  `UpdateMobileDeviceEnrollmentProfileByInvitation` updates an existing Mobile Device Enrollment Profile by its invitation.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
+  `DeleteMobileDeviceEnrollmentProfileByID` deletes a Mobile Device Enrollment Profile by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
+  `DeleteMobileDeviceEnrollmentProfileByName` deletes a Mobile Device Enrollment Profile by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
+  `DeleteMobileDeviceEnrollmentProfileByInvitation` deletes a Mobile Device Enrollment Profile by its invitation.
+
 
 ## Progress Summary
 
-- Total Endpoints: 318
-- Covered: 299
+- Total Endpoints: 331
+- Covered: 312
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/examples/mobile_device_enrollment_profiles/CreateMobileDeviceEnrollmentProfile/CreateMobileDeviceEnrollmentProfile.go
+++ b/examples/mobile_device_enrollment_profiles/CreateMobileDeviceEnrollmentProfile/CreateMobileDeviceEnrollmentProfile.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	newProfile := jamfpro.ResponseMobileDeviceEnrollmentProfile{
+		General: jamfpro.MobileDeviceEnrollmentProfileGeneral{
+			Name:        "Configurator Enrollment Profile",
+			Description: "string",
+		},
+		Location: jamfpro.MobileDeviceEnrollmentProfileLocation{
+			// Initialize with empty or specific values if required
+			Username:     "",
+			Realname:     "",
+			RealName:     "",
+			EmailAddress: "",
+			Position:     "",
+			Phone:        "",
+			PhoneNumber:  "",
+			Department:   "",
+			Building:     "",
+			Room:         0, // or specific room number
+		},
+		Purchasing: jamfpro.MobileDeviceEnrollmentProfilePurchasing{
+			IsPurchased:          true,
+			IsLeased:             false,
+			PONumber:             "",
+			Vendor:               "",
+			ApplecareID:          "",
+			PurchasePrice:        "",
+			PurchasingAccount:    "",
+			PODate:               "",
+			PODateEpoch:          0,
+			PODateUTC:            "",
+			WarrantyExpires:      "",
+			WarrantyExpiresEpoch: 0,
+			WarrantyExpiresUTC:   "",
+			LeaseExpires:         "",
+			LeaseExpiresEpoch:    0,
+			LeaseExpiresUTC:      "",
+			LifeExpectancy:       0,
+			PurchasingContact:    "",
+		},
+	}
+
+	profile, err := client.CreateMobileDeviceEnrollmentProfile(&newProfile)
+	if err != nil {
+		fmt.Println("Error creating enrollment profile:", err)
+		return
+	}
+
+	fmt.Printf("Created Profile: %+v\n", profile)
+}

--- a/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByID/DeleteMobileDeviceEnrollmentProfileByID.go
+++ b/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByID/DeleteMobileDeviceEnrollmentProfileByID.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1 // Replace with actual ID
+
+	err = client.DeleteMobileDeviceEnrollmentProfileByID(profileID)
+	if err != nil {
+		log.Fatalf("Error deleting profile by name: %v", err)
+	}
+
+	fmt.Println("Profile deleted successfully.")
+}

--- a/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByInvitation/DeleteMobileDeviceEnrollmentProfileByInvitation.go
+++ b/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByInvitation/DeleteMobileDeviceEnrollmentProfileByInvitation.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	invitation := "YourInvitationCode" // Replace with actual invitation name
+
+	err = client.DeleteMobileDeviceEnrollmentProfileByInvitation(invitation)
+	if err != nil {
+		log.Fatalf("Error deleting profile by name: %v", err)
+	}
+
+	fmt.Println("Profile deleted successfully.")
+}

--- a/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByName/DeleteMobileDeviceEnrollmentProfileByName.go
+++ b/examples/mobile_device_enrollment_profiles/DeleteMobileDeviceEnrollmentProfileByName/DeleteMobileDeviceEnrollmentProfileByName.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "Configurator Enrollment Profile" // Replace with actual name
+
+	err = client.DeleteMobileDeviceEnrollmentProfileByName(profileName)
+	if err != nil {
+		log.Fatalf("Error deleting profile by name: %v", err)
+	}
+
+	fmt.Println("Profile deleted successfully.")
+}

--- a/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByID/GetMobileDeviceEnrollmentProfileByID.go
+++ b/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByID/GetMobileDeviceEnrollmentProfileByID.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1 // Replace with the actual ID
+
+	profile, err := client.GetMobileDeviceEnrollmentProfileByID(profileID)
+	if err != nil {
+		fmt.Println("Error fetching profile by name:", err)
+		return
+	}
+	// Pretty print the extension attribute details in XML
+	applicationsXML, err := xml.MarshalIndent(profile, "", "    ") // Indent with 4 spaces and use '='
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Created Policy Details:\n", string(applicationsXML))
+}

--- a/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByIDBySubset/GetMobileDeviceEnrollmentProfileByIDBySubset.go
+++ b/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByIDBySubset/GetMobileDeviceEnrollmentProfileByIDBySubset.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1      // Replace with the actual profile ID
+	subset := "general" // Replace with the actual subset (e.g., "general")
+
+	profile, err := client.GetMobileDeviceEnrollmentProfileByIDBySubset(profileID, subset)
+	if err != nil {
+		fmt.Println("Error fetching profile by name and subset:", err)
+		return
+	}
+
+	fmt.Printf("Profile: %+v\n", profile)
+}

--- a/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByName/GetMobileDeviceEnrollmentProfileByName.go
+++ b/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByName/GetMobileDeviceEnrollmentProfileByName.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "Configurator Enrollment Profile"
+
+	profile, err := client.GetMobileDeviceEnrollmentProfileByName(profileName) // Replace with the actual name
+	if err != nil {
+		fmt.Println("Error fetching profile by name:", err)
+		return
+	}
+	// Pretty print the extension attribute details in XML
+	applicationsXML, err := xml.MarshalIndent(profile, "", "    ") // Indent with 4 spaces and use '='
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Created Policy Details:\n", string(applicationsXML))
+}

--- a/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByNameBySubset/GetMobileDeviceEnrollmentProfileByNameBySubset.go
+++ b/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfileByNameBySubset/GetMobileDeviceEnrollmentProfileByNameBySubset.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	name := "ProfileName" // Replace with the actual profile name
+	subset := "general"   // Replace with the actual subset (e.g., "general")
+
+	profile, err := client.GetMobileDeviceEnrollmentProfileByNameBySubset(name, subset)
+	if err != nil {
+		fmt.Println("Error fetching profile by name and subset:", err)
+		return
+	}
+
+	fmt.Printf("Profile: %+v\n", profile)
+}

--- a/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfiles/GetMobileDeviceEnrollmentProfiles.go
+++ b/examples/mobile_device_enrollment_profiles/GetMobileDeviceEnrollmentProfiles/GetMobileDeviceEnrollmentProfiles.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profiles, err := client.GetMobileDeviceEnrollmentProfiles()
+	if err != nil {
+		fmt.Println("Error fetching mobile device enrollment profiles:", err)
+		return
+	}
+
+	// Pretty print the extension attribute details in XML
+	applicationsXML, err := xml.MarshalIndent(profiles, "", "    ") // Indent with 4 spaces and use '='
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Created Policy Details:\n", string(applicationsXML))
+}

--- a/examples/mobile_device_enrollment_profiles/GetProfileByInvitation/GetProfileByInvitation.go
+++ b/examples/mobile_device_enrollment_profiles/GetProfileByInvitation/GetProfileByInvitation.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	invitation := "invite-name" // Replace with the actual invitation number
+
+	profile, err := client.GetProfileByInvitation(invitation)
+	if err != nil {
+		fmt.Println("Error fetching profile by invitation:", err)
+		return
+	}
+	// Pretty print the extension attribute details in XML
+	applicationsXML, err := xml.MarshalIndent(profile, "", "    ") // Indent with 4 spaces and use '='
+	if err != nil {
+		log.Fatalf("Error marshaling policy details data: %v", err)
+	}
+	fmt.Println("Created Policy Details:\n", string(applicationsXML))
+}

--- a/examples/mobile_device_enrollment_profiles/UpdateMobileDeviceEnrollmentProfileByID/UpdateMobileDeviceEnrollmentProfileByID.go
+++ b/examples/mobile_device_enrollment_profiles/UpdateMobileDeviceEnrollmentProfileByID/UpdateMobileDeviceEnrollmentProfileByID.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Example profile to be updated
+	profileToUpdate := jamfpro.ResponseMobileDeviceEnrollmentProfile{
+		General: jamfpro.MobileDeviceEnrollmentProfileGeneral{
+			Name:        "Configurator Enrollment Profile",
+			Description: "string",
+		},
+		Location: jamfpro.MobileDeviceEnrollmentProfileLocation{
+			// Initialize with empty or specific values if required
+			Username:     "",
+			Realname:     "",
+			RealName:     "",
+			EmailAddress: "",
+			Position:     "",
+			Phone:        "",
+			PhoneNumber:  "",
+			Department:   "",
+			Building:     "",
+			Room:         0, // or specific room number
+		},
+		Purchasing: jamfpro.MobileDeviceEnrollmentProfilePurchasing{
+			IsPurchased:          true,
+			IsLeased:             false,
+			PONumber:             "",
+			Vendor:               "",
+			ApplecareID:          "",
+			PurchasePrice:        "",
+			PurchasingAccount:    "",
+			PODate:               "",
+			PODateEpoch:          0,
+			PODateUTC:            "",
+			WarrantyExpires:      "",
+			WarrantyExpiresEpoch: 0,
+			WarrantyExpiresUTC:   "",
+			LeaseExpires:         "",
+			LeaseExpiresEpoch:    0,
+			LeaseExpiresUTC:      "",
+			LifeExpectancy:       0,
+			PurchasingContact:    "",
+		},
+	}
+
+	profileID := 1 // Replace 123 with the actual ID
+
+	updatedProfile, err := client.UpdateMobileDeviceEnrollmentProfileByID(profileID, &profileToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating profile: %v", err)
+	}
+
+	fmt.Println("Updated Profile:", updatedProfile)
+}

--- a/examples/mobile_device_enrollment_profiles/UpdateMobileDeviceEnrollmentProfileByName/UpdateMobileDeviceEnrollmentProfileByName.go
+++ b/examples/mobile_device_enrollment_profiles/UpdateMobileDeviceEnrollmentProfileByName/UpdateMobileDeviceEnrollmentProfileByName.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Example profile to be updated
+	profileToUpdate := jamfpro.ResponseMobileDeviceEnrollmentProfile{
+		General: jamfpro.MobileDeviceEnrollmentProfileGeneral{
+			Name:        "Configurator Enrollment Profile",
+			Description: "string",
+		},
+		Location: jamfpro.MobileDeviceEnrollmentProfileLocation{
+			// Initialize with empty or specific values if required
+			Username:     "",
+			Realname:     "",
+			RealName:     "",
+			EmailAddress: "",
+			Position:     "",
+			Phone:        "",
+			PhoneNumber:  "",
+			Department:   "",
+			Building:     "",
+			Room:         0, // or specific room number
+		},
+		Purchasing: jamfpro.MobileDeviceEnrollmentProfilePurchasing{
+			IsPurchased:          true,
+			IsLeased:             false,
+			PONumber:             "",
+			Vendor:               "",
+			ApplecareID:          "",
+			PurchasePrice:        "",
+			PurchasingAccount:    "",
+			PODate:               "",
+			PODateEpoch:          0,
+			PODateUTC:            "",
+			WarrantyExpires:      "",
+			WarrantyExpiresEpoch: 0,
+			WarrantyExpiresUTC:   "",
+			LeaseExpires:         "",
+			LeaseExpiresEpoch:    0,
+			LeaseExpiresUTC:      "",
+			LifeExpectancy:       0,
+			PurchasingContact:    "",
+		},
+	}
+
+	profileName := "Configurator Enrollment Profile" // Replace name with the actual enrollment profile name
+
+	updatedProfile, err := client.UpdateMobileDeviceEnrollmentProfileByName(profileName, &profileToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating profile: %v", err)
+	}
+
+	fmt.Println("Updated Profile:", updatedProfile)
+}

--- a/examples/mobile_device_enrollment_profiles/pdateMobileDeviceEnrollmentProfileByInvitation/pdateMobileDeviceEnrollmentProfileByInvitation.go
+++ b/examples/mobile_device_enrollment_profiles/pdateMobileDeviceEnrollmentProfileByInvitation/pdateMobileDeviceEnrollmentProfileByInvitation.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Example profile to be updated
+	profileToUpdate := jamfpro.ResponseMobileDeviceEnrollmentProfile{
+		General: jamfpro.MobileDeviceEnrollmentProfileGeneral{
+			Name:        "Configurator Enrollment Profile",
+			Description: "string",
+		},
+		Location: jamfpro.MobileDeviceEnrollmentProfileLocation{
+			// Initialize with empty or specific values if required
+			Username:     "",
+			Realname:     "",
+			RealName:     "",
+			EmailAddress: "",
+			Position:     "",
+			Phone:        "",
+			PhoneNumber:  "",
+			Department:   "",
+			Building:     "",
+			Room:         0, // or specific room number
+		},
+		Purchasing: jamfpro.MobileDeviceEnrollmentProfilePurchasing{
+			IsPurchased:          true,
+			IsLeased:             false,
+			PONumber:             "",
+			Vendor:               "",
+			ApplecareID:          "",
+			PurchasePrice:        "",
+			PurchasingAccount:    "",
+			PODate:               "",
+			PODateEpoch:          0,
+			PODateUTC:            "",
+			WarrantyExpires:      "",
+			WarrantyExpiresEpoch: 0,
+			WarrantyExpiresUTC:   "",
+			LeaseExpires:         "",
+			LeaseExpiresEpoch:    0,
+			LeaseExpiresUTC:      "",
+			LifeExpectancy:       0,
+			PurchasingContact:    "",
+		},
+	}
+
+	inviteName := "YourInvitation" // Replace name with the actual invite name
+
+	updatedProfile, err := client.UpdateMobileDeviceEnrollmentProfileByInvitation(inviteName, &profileToUpdate)
+	if err != nil {
+		log.Fatalf("Error updating profile by invitation: %v", err)
+	}
+
+	fmt.Println("Updated Profile by Invitation:", updatedProfile)
+}

--- a/sdk/http_client/sdk_version.go
+++ b/sdk/http_client/sdk_version.go
@@ -4,7 +4,7 @@ package http_client
 import "fmt"
 
 const (
-	SDKVersion    = "0.0.71"
+	SDKVersion    = "0.0.72"
 	UserAgentBase = "go-jamfpro-api-sdk"
 )
 

--- a/sdk/jamfpro/classicapi_mobile_device_enrollment_profiles.go
+++ b/sdk/jamfpro/classicapi_mobile_device_enrollment_profiles.go
@@ -1,0 +1,338 @@
+// classicapi_mobile_device_enrollment_profiles.go
+// Jamf Pro Classic Api - Mobile Device Enrollment Profiles
+// API reference: https://developer.jamf.com/jamf-pro/reference/mobiledeviceenrollmentprofiles
+// Jamf Pro Classic API requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+const uriMobileDeviceEnrollmentProfiles = "/JSSResource/mobiledeviceenrollmentprofiles"
+
+// ResponseMobileDeviceEnrollmentProfilesList represents the response for a list of mobile device enrollment profiles.
+type ResponseMobileDeviceEnrollmentProfilesList struct {
+	Size                          int                                 `xml:"size"`
+	MobileDeviceEnrollmentProfile []MobileDeviceEnrollmentProfileItem `xml:"mobile_device_enrollment_profile"`
+}
+
+// MobileDeviceEnrollmentProfileItem represents a single mobile device enrollment profile item.
+type MobileDeviceEnrollmentProfileItem struct {
+	ID         int     `xml:"id"`
+	Name       string  `xml:"name"`
+	Invitation float64 `xml:"invitation"`
+}
+
+// ResponseMobileDeviceEnrollmentProfile represents the response structure for a mobile device enrollment profile.
+type ResponseMobileDeviceEnrollmentProfile struct {
+	General     MobileDeviceEnrollmentProfileGeneral      `xml:"general"`
+	Location    MobileDeviceEnrollmentProfileLocation     `xml:"location,omitempty"`
+	Purchasing  MobileDeviceEnrollmentProfilePurchasing   `xml:"purchasing,omitempty"`
+	Attachments []MobileDeviceEnrollmentProfileAttachment `xml:"attachments,omitempty"`
+}
+
+// MobileDeviceEnrollmentProfileGeneral contains general information about the enrollment profile.
+type MobileDeviceEnrollmentProfileGeneral struct {
+	ID          int    `xml:"id"`
+	Name        string `xml:"name"`
+	Invitation  string `xml:"invitation,omitempty"`
+	UDID        string `xml:"udid,omitempty"`
+	Description string `xml:"description,omitempty"`
+}
+
+// MobileDeviceEnrollmentProfileLocation contains location information of the enrollment profile.
+type MobileDeviceEnrollmentProfileLocation struct {
+	Username     string `xml:"username,omitempty"`
+	Realname     string `xml:"realname,omitempty"`
+	RealName     string `xml:"real_name,omitempty"`
+	EmailAddress string `xml:"email_address,omitempty"`
+	Position     string `xml:"position,omitempty"`
+	Phone        string `xml:"phone,omitempty"`
+	PhoneNumber  string `xml:"phone_number,omitempty"`
+	Department   string `xml:"department,omitempty"`
+	Building     string `xml:"building,omitempty"`
+	Room         int    `xml:"room,omitempty"`
+}
+
+// MobileDeviceEnrollmentProfilePurchasing contains purchasing information of the enrollment profile.
+type MobileDeviceEnrollmentProfilePurchasing struct {
+	IsPurchased          bool   `xml:"is_purchased"`
+	IsLeased             bool   `xml:"is_leased"`
+	PONumber             string `xml:"po_number,omitempty"`
+	Vendor               string `xml:"vendor,omitempty"`
+	ApplecareID          string `xml:"applecare_id,omitempty"`
+	PurchasePrice        string `xml:"purchase_price,omitempty"`
+	PurchasingAccount    string `xml:"purchasing_account,omitempty"`
+	PODate               string `xml:"po_date,omitempty"`
+	PODateEpoch          int64  `xml:"po_date_epoch,omitempty"`
+	PODateUTC            string `xml:"po_date_utc,omitempty"`
+	WarrantyExpires      string `xml:"warranty_expires,omitempty"`
+	WarrantyExpiresEpoch int64  `xml:"warranty_expires_epoch,omitempty"`
+	WarrantyExpiresUTC   string `xml:"warranty_expires_utc,omitempty"`
+	LeaseExpires         string `xml:"lease_expires,omitempty"`
+	LeaseExpiresEpoch    int64  `xml:"lease_expires_epoch,omitempty"`
+	LeaseExpiresUTC      string `xml:"lease_expires_utc,omitempty"`
+	LifeExpectancy       int    `xml:"life_expectancy,omitempty"`
+	PurchasingContact    string `xml:"purchasing_contact,omitempty"`
+}
+
+// MobileDeviceEnrollmentProfileAttachment represents an attachment in the enrollment profile.
+type MobileDeviceEnrollmentProfileAttachment struct {
+	Attachment MobileDeviceEnrollmentProfileAttachmentItem `xml:"attachment"`
+}
+
+// MobileDeviceEnrollmentProfileAttachmentItem contains details of an attachment.
+type MobileDeviceEnrollmentProfileAttachmentItem struct {
+	ID       int    `xml:"id"`
+	Filename string `xml:"filename"`
+	URI      string `xml:"uri"`
+}
+
+// GetMobileDeviceEnrollmentProfiles retrieves a serialized list of mobile device enrollment profiles.
+func (c *Client) GetMobileDeviceEnrollmentProfiles() (*ResponseMobileDeviceEnrollmentProfilesList, error) {
+	endpoint := uriMobileDeviceEnrollmentProfiles
+
+	var enrollmentProfiles ResponseMobileDeviceEnrollmentProfilesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &enrollmentProfiles)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device enrollment profiles: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &enrollmentProfiles, nil
+}
+
+// GetMobileDeviceEnrollmentProfileByID fetches a specific mobile device enrollment profile by its ID.
+func (c *Client) GetMobileDeviceEnrollmentProfileByID(id int) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceEnrollmentProfiles, id)
+
+	var profile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device enrollment profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetMobileDeviceEnrollmentProfileByName fetches a specific mobile device enrollment profile by its name.
+func (c *Client) GetMobileDeviceEnrollmentProfileByName(name string) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceEnrollmentProfiles, name)
+
+	var profile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device enrollment profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetProfileByInvitation fetches a specific mobile device enrollment profile by its invitation.
+func (c *Client) GetProfileByInvitation(invitation string) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/invitation/%s", uriMobileDeviceEnrollmentProfiles, invitation)
+
+	var profile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device enrollment profile by invitation: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetMobileDeviceEnrollmentProfileByIDBySubset fetches a specific mobile device configuration profile by its ID and a specified subset.
+func (c *Client) GetMobileDeviceEnrollmentProfileByIDBySubset(id int, subset string) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d/subset/%s", uriMobileDeviceEnrollmentProfiles, id, subset)
+
+	var profile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device configuration profile by ID and subset: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetMobileDeviceEnrollmentProfileByNameBySubset fetches a specific mobile device configuration profile by its name and a specified subset.
+func (c *Client) GetMobileDeviceEnrollmentProfileByNameBySubset(name string, subset string) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s/subset/%s", uriMobileDeviceEnrollmentProfiles, name, subset)
+
+	var profile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device configuration profile by name and subset: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// CreateMobileDeviceEnrollmentProfile creates a new mobile device enrollment profile on the Jamf Pro server.
+func (c *Client) CreateMobileDeviceEnrollmentProfile(profile *ResponseMobileDeviceEnrollmentProfile) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriMobileDeviceEnrollmentProfiles)
+
+	// Wrap the profile with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_enrollment_profile"`
+		*ResponseMobileDeviceEnrollmentProfile
+	}{
+		ResponseMobileDeviceEnrollmentProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mobile device enrollment profile: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// UpdateMobileDeviceEnrollmentProfileByID updates a mobile device enrollment profile by its ID.
+func (c *Client) UpdateMobileDeviceEnrollmentProfileByID(id int, profile *ResponseMobileDeviceEnrollmentProfile) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceEnrollmentProfiles, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_enrollment_profile"`
+		*ResponseMobileDeviceEnrollmentProfile
+	}{
+		ResponseMobileDeviceEnrollmentProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device enrollment profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// UpdateMobileDeviceEnrollmentProfileByName updates a mobile device enrollment profile by its name.
+func (c *Client) UpdateMobileDeviceEnrollmentProfileByName(name string, profile *ResponseMobileDeviceEnrollmentProfile) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceEnrollmentProfiles, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_enrollment_profile"`
+		*ResponseMobileDeviceEnrollmentProfile
+	}{
+		ResponseMobileDeviceEnrollmentProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device enrollment profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// UpdateMobileDeviceEnrollmentProfileByInvitation updates a mobile device enrollment profile by its invitation.
+func (c *Client) UpdateMobileDeviceEnrollmentProfileByInvitation(invitation string, profile *ResponseMobileDeviceEnrollmentProfile) (*ResponseMobileDeviceEnrollmentProfile, error) {
+	endpoint := fmt.Sprintf("%s/invitation/%s", uriMobileDeviceEnrollmentProfiles, invitation)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_enrollment_profile"`
+		*ResponseMobileDeviceEnrollmentProfile
+	}{
+		ResponseMobileDeviceEnrollmentProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceEnrollmentProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device enrollment profile by invitation: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// DeleteMobileDeviceEnrollmentProfileByID deletes a mobile device enrollment profile by its ID.
+func (c *Client) DeleteMobileDeviceEnrollmentProfileByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceEnrollmentProfiles, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device enrollment profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteMobileDeviceEnrollmentProfileByName deletes a mobile device enrollment profile by its name.
+func (c *Client) DeleteMobileDeviceEnrollmentProfileByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceEnrollmentProfiles, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device enrollment profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteMobileDeviceEnrollmentProfileByInvitation deletes a mobile device enrollment profile by its invitation.
+func (c *Client) DeleteMobileDeviceEnrollmentProfileByInvitation(invitation string) error {
+	endpoint := fmt.Sprintf("%s/invitation/%s", uriMobileDeviceEnrollmentProfiles, invitation)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device enrollment profile by invitation: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Jamf Pro Classic API - Mobile Device Enrollment Profiles

added sdk coverage for endpoints with examples

## Endpoints

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles`
  `GetMobileDeviceEnrollmentProfiles` retrieves a serialized list of all Mobile Device Enrollment Profiles.

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
  `GetMobileDeviceEnrollmentProfileByID` fetches details of a single Mobile Device Enrollment Profile by its ID.

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
  `GetMobileDeviceEnrollmentProfileByName` retrieves details of a Mobile Device Enrollment Profile by its name.

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
  `GetProfileByInvitation` fetches a Mobile Device Enrollment Profile by its invitation.

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}/subset/{subset}`
  `GetMobileDeviceEnrollmentProfileByIDBySubset` fetches a specific Mobile Device Enrollment Profile by its ID and a specified subset.

- [x] ✅ **GET** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}/subset/{subset}`
  `GetMobileDeviceEnrollmentProfileByNameBySubset` fetches a specific Mobile Device Enrollment Profile by its name and a specified subset.

- [x] ✅ **POST** `/JSSResource/mobiledeviceenrollmentprofiles/id/0`
  `CreateMobileDeviceEnrollmentProfile` creates a new Mobile Device Enrollment Profile. The ID `0` in the endpoint indicates creation.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
  `UpdateMobileDeviceEnrollmentProfileByID` updates an existing Mobile Device Enrollment Profile by its ID.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
  `UpdateMobileDeviceEnrollmentProfileByName` updates an existing Mobile Device Enrollment Profile by its name.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
  `UpdateMobileDeviceEnrollmentProfileByInvitation` updates an existing Mobile Device Enrollment Profile by its invitation.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/id/{id}`
  `DeleteMobileDeviceEnrollmentProfileByID` deletes a Mobile Device Enrollment Profile by its ID.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/name/{name}`
  `DeleteMobileDeviceEnrollmentProfileByName` deletes a Mobile Device Enrollment Profile by its name.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
  `DeleteMobileDeviceEnrollmentProfileByInvitation` deletes a Mobile Device Enrollment Profile by its invitation.