### PR TITLE
+ sdk coverage for printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,11 +1020,41 @@ This documentation outlines the API endpoints available for managing Mobile Devi
 - [x] ✅ **DELETE** `/JSSResource/mobiledeviceenrollmentprofiles/invitation/{invitation}`
   `DeleteMobileDeviceEnrollmentProfileByInvitation` deletes a Mobile Device Enrollment Profile by its invitation.
 
+### Jamf Pro Classic API - Printers
+
+This documentation outlines the API endpoints available for managing printers within Jamf Pro using the Classic API, which supports XML data structures.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/printers`
+  `GetPrinters` retrieves a serialized list of all printers.
+
+- [x] ✅ **GET** `/JSSResource/printers/id/{id}`
+  `GetPrinterByID` fetches details of a single printer by its ID.
+
+- [x] ✅ **GET** `/JSSResource/printers/name/{name}`
+  `GetPrinterByName` retrieves details of a printer by its name.
+
+- [x] ✅ **POST** `/JSSResource/printers/id/0`
+  `CreatePrinters` creates a new printer. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/printers/id/{id}`
+  `UpdatePrinterByID` updates an existing printer by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/printers/name/{name}`
+  `UpdatePrinterByName` updates an existing printer by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/printers/id/{id}`
+  `DeletePrinterByID` deletes a printer by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/printers/name/{name}`
+  `DeletePrinterByName` deletes a printer by its name.
+
 
 ## Progress Summary
 
-- Total Endpoints: 331
-- Covered: 312
+- Total Endpoints: 339
+- Covered: 320
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/examples/printers/CreatePrinters/CreatePrinters.go
+++ b/examples/printers/CreatePrinters/CreatePrinters.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Printer details to create
+	newPrinter := &jamfpro.ResponsePrinters{
+		Name:        "HP 9th Floor",
+		Category:    "",
+		URI:         "lpd://10.1.20.204/",
+		CUPSName:    "HP_9th_Floor",
+		Location:    "string",
+		Model:       "HP LaserJet 500 color MFP M575",
+		Info:        "string",
+		Notes:       "string",
+		MakeDefault: true,
+		UseGeneric:  true,
+		PPD:         "9th_Floor_HP.ppd",
+		PPDPath:     "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Resources/Generic.ppd",
+		PPDContents: "string",
+	}
+
+	createdPrinter, err := client.CreatePrinters(newPrinter)
+	if err != nil {
+		fmt.Println("Error creating printer:", err)
+		return
+	}
+
+	fmt.Printf("Printer created successfully:\nID: %d\nName: %s\n", createdPrinter.ID, createdPrinter.Name)
+}

--- a/examples/printers/DeletePrinterByID/DeletePrinterByID.go
+++ b/examples/printers/DeletePrinterByID/DeletePrinterByID.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	id := 1 // Replace with the actual printer ID
+
+	err = client.DeletePrinterByID(id)
+	if err != nil {
+		fmt.Println("Error deleting printer:", err)
+		return
+	}
+
+	fmt.Println("Printer deleted successfully")
+}

--- a/examples/printers/DeletePrinterByName/DeletePrinterByName.go
+++ b/examples/printers/DeletePrinterByName/DeletePrinterByName.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	name := "HP 9th Floor" // Replace with the actual printer name
+
+	err = client.DeletePrinterByName(name)
+	if err != nil {
+		fmt.Println("Error deleting printer:", err)
+		return
+	}
+
+	fmt.Println("Printer deleted successfully")
+}

--- a/examples/printers/GetPrinterByID/GetPrinterByID.go
+++ b/examples/printers/GetPrinterByID/GetPrinterByID.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Example ID to fetch
+	printerID := 1
+
+	printer, err := client.GetPrinterByID(printerID)
+	if err != nil {
+		fmt.Println("Error fetching printer by ID:", err)
+		return
+	}
+
+	// Pretty print the created script details in XML
+	createdPrintersXML, err := xml.MarshalIndent(printer, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created script data: %v", err)
+	}
+	fmt.Println("Created Script Details:\n", string(createdPrintersXML))
+}

--- a/examples/printers/GetPrinterByName/GetPrinterByName.go
+++ b/examples/printers/GetPrinterByName/GetPrinterByName.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Example ID to fetch
+	printerName := "printer-name"
+
+	printer, err := client.GetPrinterByName(printerName)
+	if err != nil {
+		fmt.Println("Error fetching printer by ID:", err)
+		return
+	}
+
+	// Pretty print the created script details in XML
+	createdPrintersXML, err := xml.MarshalIndent(printer, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created script data: %v", err)
+	}
+	fmt.Println("Created Script Details:\n", string(createdPrintersXML))
+}

--- a/examples/printers/GetPrinters/GetPrinters.go
+++ b/examples/printers/GetPrinters/GetPrinters.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	printers, err := client.GetPrinters()
+	if err != nil {
+		fmt.Println("Error fetching printers:", err)
+		return
+	}
+
+	// Pretty print the created script details in XML
+	createdPrintersXML, err := xml.MarshalIndent(printers, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling created script data: %v", err)
+	}
+	fmt.Println("Created Script Details:\n", string(createdPrintersXML))
+}

--- a/examples/printers/UpdatePrinterByID/UpdatePrinterByID.go
+++ b/examples/printers/UpdatePrinterByID/UpdatePrinterByID.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Printer details to create
+	updatedPrinter := &jamfpro.ResponsePrinters{
+		Name:        "HP 9th Floor",
+		Category:    "",
+		URI:         "lpd://10.1.20.204/",
+		CUPSName:    "HP_9th_Floor",
+		Location:    "string",
+		Model:       "HP LaserJet 500 color MFP M575",
+		Info:        "string",
+		Notes:       "string",
+		MakeDefault: true,
+		UseGeneric:  true,
+		PPD:         "9th_Floor_HP.ppd",
+		PPDPath:     "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Resources/Generic.ppd",
+		PPDContents: "string",
+	}
+
+	id := 1 // Replace with the actual printer ID
+	updatedPrinter, err = client.UpdatePrinterByID(id, updatedPrinter)
+	if err != nil {
+		fmt.Println("Error updating printer:", err)
+		return
+	}
+
+	fmt.Println("Printer updated successfully:", updatedPrinter.Name)
+}

--- a/examples/printers/UpdatePrinterByName/UpdatePrinterByName.go
+++ b/examples/printers/UpdatePrinterByName/UpdatePrinterByName.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Printer details to create
+	updatedPrinter := &jamfpro.ResponsePrinters{
+		Name:        "HP 9th Floor",
+		Category:    "",
+		URI:         "lpd://10.1.20.204/",
+		CUPSName:    "HP_9th_Floor",
+		Location:    "string",
+		Model:       "HP LaserJet 500 color MFP M575",
+		Info:        "string",
+		Notes:       "string",
+		MakeDefault: true,
+		UseGeneric:  true,
+		PPD:         "9th_Floor_HP.ppd",
+		PPDPath:     "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/PrintCore.framework/Resources/Generic.ppd",
+		PPDContents: "string",
+	}
+
+	name := "HP 9th Floor" // Replace with the actual printer name
+	updatedPrinter, err = client.UpdatePrinterByName(name, updatedPrinter)
+	if err != nil {
+		fmt.Println("Error updating printer:", err)
+		return
+	}
+
+	fmt.Println("Printer updated successfully:", updatedPrinter.Name)
+}

--- a/sdk/http_client/sdk_version.go
+++ b/sdk/http_client/sdk_version.go
@@ -4,7 +4,7 @@ package http_client
 import "fmt"
 
 const (
-	SDKVersion    = "0.0.72"
+	SDKVersion    = "0.0.73"
 	UserAgentBase = "go-jamfpro-api-sdk"
 )
 

--- a/sdk/jamfpro/classicapi_printers.go
+++ b/sdk/jamfpro/classicapi_printers.go
@@ -1,0 +1,201 @@
+// classicapi_printers.go
+// Jamf Pro Classic Api - Printers
+// api reference: https://developer.jamf.com/jamf-pro/reference/printers
+// Jamf Pro Classic Api requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+const uriPrinters = "/JSSResource/printers"
+
+// ResponsePrintersList represents the response for a list of printers.
+type ResponsePrintersList struct {
+	Size    int           `xml:"size"`
+	Printer []PrinterItem `xml:"printer"`
+}
+
+// PrinterItem represents a single printer item.
+type PrinterItem struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+// ResponsePrinters represents the detailed structure of a single printer.
+type ResponsePrinters struct {
+	ID          int    `xml:"id"`
+	Name        string `xml:"name"`
+	Category    string `xml:"category"`
+	URI         string `xml:"uri"`
+	CUPSName    string `xml:"CUPS_name"`
+	Location    string `xml:"location"`
+	Model       string `xml:"model"`
+	Info        string `xml:"info"`
+	Notes       string `xml:"notes"`
+	MakeDefault bool   `xml:"make_default"`
+	UseGeneric  bool   `xml:"use_generic"`
+	PPD         string `xml:"ppd"`
+	PPDPath     string `xml:"ppd_path"`
+	PPDContents string `xml:"ppd_contents"`
+}
+
+// GetPrinters retrieves a serialized list of printers.
+func (c *Client) GetPrinters() (*ResponsePrintersList, error) {
+	endpoint := uriPrinters
+
+	var printers ResponsePrintersList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &printers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch printers: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &printers, nil
+}
+
+// GetPrinterByID fetches a specific printer by its ID.
+func (c *Client) GetPrinterByID(id int) (*ResponsePrinters, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPrinters, id)
+
+	var printer ResponsePrinters
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &printer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch printer by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &printer, nil
+}
+
+// GetPrinterByName fetches a specific printer by its name.
+func (c *Client) GetPrinterByName(name string) (*ResponsePrinters, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPrinters, name)
+
+	var printer ResponsePrinters
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &printer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch printer by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &printer, nil
+}
+
+// CreatePrinters creates a new printer on the Jamf Pro server.
+func (c *Client) CreatePrinters(printer *ResponsePrinters) (*ResponsePrinters, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriPrinters)
+
+	// Wrap the printer with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"printer"`
+		*ResponsePrinters
+	}{
+		ResponsePrinters: printer,
+	}
+
+	var responsePrinter ResponsePrinters
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responsePrinter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create printer: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responsePrinter, nil
+}
+
+// UpdatePrinterByID updates a printer by its ID.
+func (c *Client) UpdatePrinterByID(id int, printer *ResponsePrinters) (*ResponsePrinters, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPrinters, id)
+
+	// Wrap the printer with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"printer"`
+		*ResponsePrinters
+	}{
+		ResponsePrinters: printer,
+	}
+
+	var responsePrinter ResponsePrinters
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responsePrinter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update printer by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responsePrinter, nil
+}
+
+// UpdatePrinterByName updates a printer by its name.
+func (c *Client) UpdatePrinterByName(name string, printer *ResponsePrinters) (*ResponsePrinters, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPrinters, name)
+
+	// Wrap the printer with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"printer"`
+		*ResponsePrinters
+	}{
+		ResponsePrinters: printer,
+	}
+
+	var responsePrinter ResponsePrinters
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responsePrinter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update printer by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responsePrinter, nil
+}
+
+// DeletePrinterByID deletes a printer by its ID.
+func (c *Client) DeletePrinterByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriPrinters, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete printer by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeletePrinterByName deletes a printer by its name.
+func (c *Client) DeletePrinterByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriPrinters, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete printer by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Jamf Pro Classic API - Printers

This documentation outlines the API endpoints available for managing printers within Jamf Pro using the Classic API, which supports XML data structures.

## Endpoints

- [x] ✅ **GET** `/JSSResource/printers`
  `GetPrinters` retrieves a serialized list of all printers.

- [x] ✅ **GET** `/JSSResource/printers/id/{id}`
  `GetPrinterByID` fetches details of a single printer by its ID.

- [x] ✅ **GET** `/JSSResource/printers/name/{name}`
  `GetPrinterByName` retrieves details of a printer by its name.

- [x] ✅ **POST** `/JSSResource/printers/id/0`
  `CreatePrinters` creates a new printer. The ID `0` in the endpoint indicates creation.

- [x] ✅ **PUT** `/JSSResource/printers/id/{id}`
  `UpdatePrinterByID` updates an existing printer by its ID.

- [x] ✅ **PUT** `/JSSResource/printers/name/{name}`
  `UpdatePrinterByName` updates an existing printer by its name.

- [x] ✅ **DELETE** `/JSSResource/printers/id/{id}`
  `DeletePrinterByID` deletes a printer by its ID.

- [x] ✅ **DELETE** `/JSSResource/printers/name/{name}`
  `DeletePrinterByName` deletes a printer by its name.