### PR TITLE
+ sdk coverage for network segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1050,11 +1050,41 @@ This documentation outlines the API endpoints available for managing printers wi
 - [x] ✅ **DELETE** `/JSSResource/printers/name/{name}`
   `DeletePrinterByName` deletes a printer by its name.
 
+### Jamf Pro Classic API - Network Segments
+
+This documentation outlines the API endpoints available for managing Network Segments within Jamf Pro using the Classic API, which supports XML data structures.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/networksegments`
+  `GetNetworkSegments` retrieves a serialized list of all Network Segments.
+
+- [x] ✅ **GET** `/JSSResource/networksegments/id/{id}`
+  `GetNetworkSegmentByID` fetches details of a single Network Segment by its ID.
+
+- [x] ✅ **GET** `/JSSResource/networksegments/name/{name}`
+  `GetNetworkSegmentByName` retrieves details of a Network Segment by its name.
+
+- [x] ✅ **POST** `/JSSResource/networksegments/id/0`
+  `CreateNetworkSegment` creates a new Network Segment. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/networksegments/id/{id}`
+  `UpdateNetworkSegmentByID` updates an existing Network Segment by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/networksegments/name/{name}`
+  `UpdateNetworkSegmentByName` updates an existing Network Segment by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/networksegments/id/{id}`
+  `DeleteNetworkSegmentByID` deletes a Network Segment by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/networksegments/name/{name}`
+  `DeleteNetworkSegmentByName` deletes a Network Segment by its name.
+
 
 ## Progress Summary
 
-- Total Endpoints: 339
-- Covered: 320
+- Total Endpoints: 347
+- Covered: 328
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/examples/network_segments/CreateNetworkSegment/CreateNetworkSegment.go
+++ b/examples/network_segments/CreateNetworkSegment/CreateNetworkSegment.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the new network segment
+	newSegment := &jamfpro.ResponseNetworkSegment{
+		Name:                "NY Office",
+		StartingAddress:     "10.1.1.1",
+		EndingAddress:       "10.10.1.1",
+		OverrideBuildings:   false,
+		OverrideDepartments: false,
+	}
+
+	// Create the network segment
+	createdSegment, err := client.CreateNetworkSegment(newSegment)
+	if err != nil {
+		log.Fatalf("Error creating network segment: %v", err)
+	}
+
+	// Pretty print the created network segment details in XML
+	segmentXML, err := xml.MarshalIndent(createdSegment, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling network segment details: %v", err)
+	}
+	fmt.Println("Created Network Segment Details:\n", string(segmentXML))
+}

--- a/examples/network_segments/DeleteNetworkSegmentByID/DeleteNetworkSegmentByID.go
+++ b/examples/network_segments/DeleteNetworkSegmentByID/DeleteNetworkSegmentByID.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	segmentID := 1 // Replace with actual ID of the network segment to delete
+
+	err = client.DeleteNetworkSegmentByID(segmentID)
+	if err != nil {
+		log.Fatalf("Error deleting network segment by ID: %v", err)
+	} else {
+		fmt.Printf("Network segment with ID %d successfully deleted.\n", segmentID)
+	}
+}

--- a/examples/network_segments/DeleteNetworkSegmentByName/DeleteNetworkSegmentByName.go
+++ b/examples/network_segments/DeleteNetworkSegmentByName/DeleteNetworkSegmentByName.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	segmentName := "NY Office" // Replace with the actual name of the network segment to delete
+
+	err = client.DeleteNetworkSegmentByName(segmentName)
+	if err != nil {
+		log.Fatalf("Error deleting network segment by name: %v", err)
+	} else {
+		fmt.Printf("Network segment '%s' successfully deleted.\n", segmentName)
+	}
+}

--- a/examples/network_segments/GetNetworkSegmentByID/GetNetworkSegmentByID.go
+++ b/examples/network_segments/GetNetworkSegmentByID/GetNetworkSegmentByID.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Retrieve a network segment by ID
+	id := 1 // Replace with actual ID
+	segment, err := client.GetNetworkSegmentByID(id)
+	if err != nil {
+		log.Fatalf("Error fetching network segment by ID: %v", err)
+	}
+
+	// Pretty print the network segments in XML
+	segmentsXML, err := xml.MarshalIndent(segment, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling network segments data: %v", err)
+	}
+	fmt.Println("Network Segments:\n", string(segmentsXML))
+}

--- a/examples/network_segments/GetNetworkSegmentByName/GetNetworkSegmentByName.go
+++ b/examples/network_segments/GetNetworkSegmentByName/GetNetworkSegmentByName.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Retrieve a network segment by name
+	name := "NY Office" // Replace with actual name
+	segment, err := client.GetNetworkSegmentByName(name)
+	if err != nil {
+		log.Fatalf("Error fetching network segment by name: %v", err)
+	}
+
+	// Pretty print the network segments in XML
+	segmentsXML, err := xml.MarshalIndent(segment, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling network segments data: %v", err)
+	}
+	fmt.Println("Network Segments:\n", string(segmentsXML))
+}

--- a/examples/network_segments/GetNetworkSegments/GetNetworkSegments.go
+++ b/examples/network_segments/GetNetworkSegments/GetNetworkSegments.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	segments, err := client.GetNetworkSegments()
+	if err != nil {
+		fmt.Println("Error fetching network segments:", err)
+		return
+	}
+
+	// Pretty print the network segments in XML
+	segmentsXML, err := xml.MarshalIndent(segments, "", "    ") // Indent with 4 spaces
+	if err != nil {
+		log.Fatalf("Error marshaling network segments data: %v", err)
+	}
+	fmt.Println("Network Segments:\n", string(segmentsXML))
+}

--- a/examples/network_segments/UpdateNetworkSegmentByID/UpdateNetworkSegmentByID.go
+++ b/examples/network_segments/UpdateNetworkSegmentByID/UpdateNetworkSegmentByID.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the new network segment
+	updatedSegment := &jamfpro.ResponseNetworkSegment{
+		Name:                "NY Office",
+		StartingAddress:     "10.1.1.1",
+		EndingAddress:       "10.10.1.1",
+		OverrideBuildings:   false,
+		OverrideDepartments: false,
+	}
+
+	segmentID := 1 // Replace with actual ID
+
+	updated, err := client.UpdateNetworkSegmentByID(segmentID, updatedSegment)
+	if err != nil {
+		log.Fatalf("Error updating network segment by ID: %v", err)
+	}
+
+	// Print the updated network segment details
+	segmentXML, _ := xml.MarshalIndent(updated, "", "    ")
+	fmt.Println("Updated Network Segment:", string(segmentXML))
+}

--- a/examples/network_segments/UpdateNetworkSegmentByName/UpdateNetworkSegmentByName.go
+++ b/examples/network_segments/UpdateNetworkSegmentByName/UpdateNetworkSegmentByName.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName: authConfig.InstanceName,
+		LogLevel:     logLevel,
+		Logger:       logger,
+		ClientID:     authConfig.ClientID,
+		ClientSecret: authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Define the new network segment
+	updatedSegment := &jamfpro.ResponseNetworkSegment{
+		Name:                "NY Office",
+		StartingAddress:     "10.1.1.1",
+		EndingAddress:       "10.10.1.1",
+		OverrideBuildings:   false,
+		OverrideDepartments: false,
+	}
+
+	segmentName := "NY Office" // Replace with actual name
+
+	updated, err := client.UpdateNetworkSegmentByName(segmentName, updatedSegment)
+	if err != nil {
+		log.Fatalf("Error updating network segment by name: %v", err)
+	}
+
+	// Print the updated network segment details
+	segmentXML, _ := xml.MarshalIndent(updated, "", "    ")
+	fmt.Println("Updated Network Segment:", string(segmentXML))
+}

--- a/sdk/jamfpro/classicapi_network_segments.go
+++ b/sdk/jamfpro/classicapi_network_segments.go
@@ -5,7 +5,24 @@
 
 package jamfpro
 
+import (
+	"encoding/xml"
+	"fmt"
+)
+
 const uriNetworkSegments = "/JSSResource/networksegments"
+
+type NetworkSegmentList struct {
+	Size    int                  `xml:"size"`
+	Results []NetworkSegmentItem `xml:"network_segment"`
+}
+
+type NetworkSegmentItem struct {
+	ID              int    `xml:"id"`
+	Name            string `xml:"name"`
+	StartingAddress string `xml:"starting_address"`
+	EndingAddress   string `xml:"ending_address"`
+}
 
 type ResponseNetworkSegment struct {
 	ID                  int    `json:"id" xml:"id"`
@@ -22,15 +39,156 @@ type ResponseNetworkSegment struct {
 	OverrideDepartments bool   `json:"override_departments" xml:"override_departments"`
 }
 
-type NetworkSegmentList struct {
-	Size    int                      `json:"size" xml:"size"`
-	Results []ResponseNetworkSegment `json:"network_segment" xml:"network_segment"`
+// GetNetworkSegments retrieves a list of network segments.
+func (c *Client) GetNetworkSegments() (*NetworkSegmentList, error) {
+	endpoint := uriNetworkSegments
+
+	var segments NetworkSegmentList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &segments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch network segments: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &segments, nil
 }
 
-type NetworkSegmentScope struct {
-	ID   int    `xml:"id"`
-	UID  string `xml:"uid,omitempty"`
-	Name int    `xml:"name"`
+// GetNetworkSegmentByID retrieves a specific network segment by its ID.
+func (c *Client) GetNetworkSegmentByID(id int) (*ResponseNetworkSegment, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriNetworkSegments, id)
+
+	var segment ResponseNetworkSegment
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &segment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch network segment by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &segment, nil
 }
 
-// Functions TODO
+// GetNetworkSegmentByName retrieves a specific network segment by its name.
+func (c *Client) GetNetworkSegmentByName(name string) (*ResponseNetworkSegment, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriNetworkSegments, name)
+
+	var segment ResponseNetworkSegment
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &segment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch network segment by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &segment, nil
+}
+
+// CreateNetworkSegment creates a new network segment on the Jamf Pro server.
+func (c *Client) CreateNetworkSegment(segment *ResponseNetworkSegment) (*ResponseNetworkSegment, error) {
+	endpoint := fmt.Sprintf("%s/id/0", uriNetworkSegments)
+
+	// Wrap the segment with the desired XML name using an anonymous struct
+	requestBody := struct {
+		XMLName xml.Name `xml:"network_segment"`
+		*ResponseNetworkSegment
+	}{
+		ResponseNetworkSegment: segment,
+	}
+
+	var responseSegment ResponseNetworkSegment
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responseSegment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create network segment: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseSegment, nil
+}
+
+// UpdateNetworkSegmentByID updates a specific network segment by its ID.
+func (c *Client) UpdateNetworkSegmentByID(id int, segment *ResponseNetworkSegment) (*ResponseNetworkSegment, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriNetworkSegments, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"network_segment"`
+		*ResponseNetworkSegment
+	}{
+		ResponseNetworkSegment: segment,
+	}
+
+	var responseSegment ResponseNetworkSegment
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responseSegment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update network segment by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseSegment, nil
+}
+
+// UpdateNetworkSegmentByName updates a specific network segment by its name.
+func (c *Client) UpdateNetworkSegmentByName(name string, segment *ResponseNetworkSegment) (*ResponseNetworkSegment, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriNetworkSegments, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"network_segment"`
+		*ResponseNetworkSegment
+	}{
+		ResponseNetworkSegment: segment,
+	}
+
+	var responseSegment ResponseNetworkSegment
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &responseSegment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update network segment by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseSegment, nil
+}
+
+// DeleteNetworkSegmentByID deletes a policy by its ID.
+func (c *Client) DeleteNetworkSegmentByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriNetworkSegments, id)
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteNetworkSegmentByName deletes a policy by its name.
+func (c *Client) DeleteNetworkSegmentByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriNetworkSegments, name)
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete policy: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Jamf Pro Classic API - Network Segments

Added SDK coverage for network segments with examples

## Endpoints

- [x] ✅ **GET** `/JSSResource/networksegments`
  `GetNetworkSegments` retrieves a serialized list of all Network Segments.

- [x] ✅ **GET** `/JSSResource/networksegments/id/{id}`
  `GetNetworkSegmentByID` fetches details of a single Network Segment by its ID.

- [x] ✅ **GET** `/JSSResource/networksegments/name/{name}`
  `GetNetworkSegmentByName` retrieves details of a Network Segment by its name.

- [x] ✅ **POST** `/JSSResource/networksegments/id/0`
  `CreateNetworkSegment` creates a new Network Segment. The ID `0` in the endpoint indicates creation.

- [x] ✅ **PUT** `/JSSResource/networksegments/id/{id}`
  `UpdateNetworkSegmentByID` updates an existing Network Segment by its ID.

- [x] ✅ **PUT** `/JSSResource/networksegments/name/{name}`
  `UpdateNetworkSegmentByName` updates an existing Network Segment by its name.

- [x] ✅ **DELETE** `/JSSResource/networksegments/id/{id}`
  `DeleteNetworkSegmentByID` deletes a Network Segment by its ID.

- [x] ✅ **DELETE** `/JSSResource/networksegments/name/{name}`
  `DeleteNetworkSegmentByName` deletes a Network Segment by its name.
