### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,11 +1086,41 @@ This documentation outlines the API endpoints available for managing Network Seg
 - [x] ✅ **DELETE** `/JSSResource/networksegments/name/{name}`
   `DeleteNetworkSegmentByName` deletes a Network Segment by its name.
 
+### Jamf Pro Classic API - Mobile Device Groups
+
+This documentation outlines the API endpoints available for managing Mobile Device Groups within Jamf Pro using the Classic API, which supports XML data structures.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/mobiledevicegroups`
+  `GetMobileDeviceGroups` retrieves a serialized list of all Mobile Device Groups.
+
+- [x] ✅ **GET** `/JSSResource/mobiledevicegroups/id/{id}`
+  `GetMobileDeviceGroupByID` fetches details of a single Mobile Device Group by its ID.
+
+- [x] ✅ **GET** `/JSSResource/mobiledevicegroups/name/{name}`
+  `GetMobileDeviceGroupByName` retrieves details of a Mobile Device Group by its name.
+
+- [x] ✅ **POST** `/JSSResource/mobiledevicegroups/id/0`
+  `CreateMobileDeviceGroup` creates a new Mobile Device Group. The ID `0` in the endpoint indicates creation.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledevicegroups/id/{id}`
+  `UpdateMobileDeviceGroupByID` updates an existing Mobile Device Group by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledevicegroups/name/{name}`
+  `UpdateMobileDeviceGroupByName` updates an existing Mobile Device Group by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledevicegroups/id/{id}`
+  `DeleteMobileDeviceGroupByID` deletes a Mobile Device Group by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledevicegroups/name/{name}`
+  `DeleteMobileDeviceGroupByName` deletes a Mobile Device Group by its name.
+
 
 ## Progress Summary
 
-- Total Endpoints: 347
-- Covered: 328
+- Total Endpoints: 355
+- Covered: 336
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,51 @@ This documentation outlines the API endpoints available for managing Mobile Devi
 - [x] ✅ **DELETE** `/JSSResource/mobiledevicegroups/name/{name}`
   `DeleteMobileDeviceGroupByName` deletes a Mobile Device Group by its name.
 
+### Jamf Pro Classic API - Mobile Device Provisioning Profiles
+
+This documentation outlines the API endpoints available for managing Mobile Device Provisioning Profiles within Jamf Pro using the Classic API, which supports XML data structures.
+
+## Endpoints
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles`
+  `GetMobileDeviceProvisioningProfiles` retrieves a serialized list of all Mobile Device Provisioning Profiles.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
+  `GetMobileDeviceProvisioningProfileByID` fetches a specific Mobile Device Provisioning Profile by its ID.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
+  `GetMobileDeviceProvisioningProfileByName` fetches a specific Mobile Device Provisioning Profile by its name.
+
+- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
+  `GetMobileDeviceProvisioningProfileByUUID` fetches a specific Mobile Device Provisioning Profile by its UUID.
+
+- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
+  `CreateMobileDeviceProvisioningProfileByID` creates a new Mobile Device Provisioning Profile by its ID.
+
+- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
+  `CreateMobileDeviceProvisioningProfileByName` creates a new Mobile Device Provisioning Profile by its name.
+
+- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
+  `CreateMobileDeviceProvisioningProfileByUUID` creates a new Mobile Device Provisioning Profile by its UUID.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
+  `UpdateMobileDeviceProvisioningProfileByID` updates an existing Mobile Device Provisioning Profile by its ID.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
+  `UpdateMobileDeviceProvisioningProfileByName` updates an existing Mobile Device Provisioning Profile by its name.
+
+- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
+  `UpdateMobileDeviceProvisioningProfileByUUID` updates an existing Mobile Device Provisioning Profile by its UUID.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
+  `DeleteMobileDeviceProvisioningProfileByID` deletes a Mobile Device Provisioning Profile by its ID.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
+  `DeleteMobileDeviceProvisioningProfileByName` deletes a Mobile Device Provisioning Profile by its name.
+
+- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
+  `DeleteMobileDeviceProvisioningProfileByUUID` deletes a Mobile Device Provisioning Profile by its UUID.
+
 
 ## Progress Summary
 

--- a/README.md
+++ b/README.md
@@ -1164,8 +1164,8 @@ This documentation outlines the API endpoints available for managing Mobile Devi
 
 ## Progress Summary
 
-- Total Endpoints: 355
-- Covered: 336
+- Total Endpoints: 3568
+- Covered: 349
 - Not Covered: 19
 - Partially Covered: 0
 

--- a/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByID/CreateMobileDeviceProvisioningProfileByID.go
+++ b/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByID/CreateMobileDeviceProvisioningProfileByID.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 123 // Replace with the actual ID
+	newProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	createdProfile, err := client.CreateMobileDeviceProvisioningProfileByID(profileID, newProfile)
+	if err != nil {
+		log.Fatalf("Error creating mobile device provisioning profile: %s\n", err)
+	}
+
+	createdProfileXML, err := xml.MarshalIndent(createdProfile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling created profile data: %v", err)
+	}
+	fmt.Println("Created Mobile Device Provisioning Profile:\n", string(createdProfileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByName/CreateMobileDeviceProvisioningProfileByName.go
+++ b/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByName/CreateMobileDeviceProvisioningProfileByName.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "in-house app profile creation by name" // Replace with the actual profile name
+	newProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile creation by name",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	createdProfile, err := client.CreateMobileDeviceProvisioningProfileByName(profileName, newProfile)
+	if err != nil {
+		log.Fatalf("Error creating mobile device provisioning profile: %s\n", err)
+	}
+
+	createdProfileXML, err := xml.MarshalIndent(createdProfile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling created profile data: %v", err)
+	}
+	fmt.Println("Created Mobile Device Provisioning Profile:\n", string(createdProfileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByUUID/CreateMobileDeviceProvisioningProfileByUUID.go
+++ b/examples/mobile_device_provisioning_profiles/CreateMobileDeviceProvisioningProfileByUUID/CreateMobileDeviceProvisioningProfileByUUID.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileUUID := "116AF1E6-7EB5-4335-B598-276CDE5E015B" // Replace with the actual UUID
+	newProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	createdProfile, err := client.CreateMobileDeviceProvisioningProfileByUUID(profileUUID, newProfile)
+	if err != nil {
+		log.Fatalf("Error creating mobile device provisioning profile: %s\n", err)
+	}
+
+	createdProfileXML, err := xml.MarshalIndent(createdProfile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling created profile data: %v", err)
+	}
+	fmt.Println("Created Mobile Device Provisioning Profile:\n", string(createdProfileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByID/DeleteMobileDeviceProvisioningProfileByID.go
+++ b/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByID/DeleteMobileDeviceProvisioningProfileByID.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1 // Replace with the actual ID to delete
+
+	err = client.DeleteMobileDeviceProvisioningProfileByID(profileID)
+	if err != nil {
+		log.Fatalf("Error deleting mobile device provisioning profile by ID: %v", err)
+	}
+
+	fmt.Printf("Mobile Device Provisioning Profile with ID %d deleted successfully\n", profileID)
+}

--- a/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByName/DeleteMobileDeviceProvisioningProfileByName.go
+++ b/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByName/DeleteMobileDeviceProvisioningProfileByName.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "ProfileName" // Replace with the actual name of the profile to delete
+
+	err = client.DeleteMobileDeviceProvisioningProfileByName(profileName)
+	if err != nil {
+		log.Fatalf("Error deleting mobile device provisioning profile by name: %v", err)
+	}
+
+	fmt.Printf("Mobile Device Provisioning Profile with name '%s' deleted successfully\n", profileName)
+}

--- a/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByUUID/DeleteMobileDeviceProvisioningProfileByUUID.go
+++ b/examples/mobile_device_provisioning_profiles/DeleteMobileDeviceProvisioningProfileByUUID/DeleteMobileDeviceProvisioningProfileByUUID.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileUUID := "116AF1E6-7EB5-4335-B598-276CDE5E015B" // Replace with the actual UUID of the profile to delete
+
+	err = client.DeleteMobileDeviceProvisioningProfileByUUID(profileUUID)
+	if err != nil {
+		log.Fatalf("Error deleting mobile device provisioning profile by UUID: %v", err)
+	}
+
+	fmt.Printf("Mobile Device Provisioning Profile with UUID '%s' deleted successfully\n", profileUUID)
+}

--- a/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByID/GetMobileDeviceProvisioningProfileByID.go
+++ b/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByID/GetMobileDeviceProvisioningProfileByID.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1 // Replace with the actual profile ID
+
+	profile, err := client.GetMobileDeviceProvisioningProfileByID(profileID)
+	if err != nil {
+		log.Fatalf("Error fetching mobile device provisioning profile by profileID: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling profile data: %v", err)
+	}
+	fmt.Printf("Mobile Device Provisioning Profile Details:\n%s\n", string(profileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByName/GetMobileDeviceProvisioningProfileByName.go
+++ b/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByName/GetMobileDeviceProvisioningProfileByName.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "profile-name" // Replace with the actual profile Name
+
+	profile, err := client.GetMobileDeviceProvisioningProfileByName(profileName)
+	if err != nil {
+		log.Fatalf("Error fetching mobile device provisioning profile by profileName: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling profile data: %v", err)
+	}
+	fmt.Printf("Mobile Device Provisioning Profile Details:\n%s\n", string(profileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByUUID/GetMobileDeviceProvisioningProfileByUUID.go
+++ b/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfileByUUID/GetMobileDeviceProvisioningProfileByUUID.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client" // Import http_client for logging
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelDebug // LogLevelNone // LogLevelWarning // LogLevelInfo  // LogLevelDebug
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	uuid := "116AF1E6-7EB5-4335-B598-276CDE5E015B" // Replace with the actual UUID
+
+	profile, err := client.GetMobileDeviceProvisioningProfileByUUID(uuid)
+	if err != nil {
+		log.Fatalf("Error fetching mobile device provisioning profile by UUID: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling profile data: %v", err)
+	}
+	fmt.Printf("Mobile Device Provisioning Profile Details:\n%s\n", string(profileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfiles/GetMobileDeviceProvisioningProfiles.go
+++ b/examples/mobile_device_provisioning_profiles/GetMobileDeviceProvisioningProfiles/GetMobileDeviceProvisioningProfiles.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	// Fetch mobile device provisioning profiles
+	profiles, err := client.GetMobileDeviceProvisioningProfiles()
+	if err != nil {
+		log.Fatalf("Error fetching mobile device provisioning profiles: %s\n", err)
+	}
+
+	// Print the profiles in a formatted XML
+	profilesXML, err := xml.MarshalIndent(profiles, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling profiles data: %v", err)
+	}
+	fmt.Println("Mobile Device Provisioning Profiles:\n", string(profilesXML))
+}

--- a/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByID/UpdateMobileDeviceProvisioningProfileByID.go
+++ b/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByID/UpdateMobileDeviceProvisioningProfileByID.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileID := 1 // Replace with the actual ID
+
+	updatedProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	profile, err := client.UpdateMobileDeviceProvisioningProfileByID(profileID, updatedProfile)
+	if err != nil {
+		log.Fatalf("Error updating mobile device provisioning profile by ID: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated profile data: %v", err)
+	}
+	fmt.Println("Updated Mobile Device Provisioning Profile (ByID):\n", string(profileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByName/UpdateMobileDeviceProvisioningProfileByName.go
+++ b/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByName/UpdateMobileDeviceProvisioningProfileByName.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileName := "provisoning-profile-name" // Replace with the actual Name
+
+	updatedProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	profile, err := client.UpdateMobileDeviceProvisioningProfileByName(profileName, updatedProfile)
+	if err != nil {
+		log.Fatalf("Error updating mobile device provisioning profile by Name: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated profile data: %v", err)
+	}
+	fmt.Println("Updated Mobile Device Provisioning Profile (ByName):\n", string(profileXML))
+}

--- a/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByUUID/UpdateMobileDeviceProvisioningProfileByUUID.go
+++ b/examples/mobile_device_provisioning_profiles/UpdateMobileDeviceProvisioningProfileByUUID/UpdateMobileDeviceProvisioningProfileByUUID.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/http_client"
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/GitHub/deploymenttheory/go-api-sdk-jamfpro/clientauth.json"
+
+	// Load the client OAuth credentials from the configuration file
+	authConfig, err := jamfpro.LoadClientAuthConfig(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to load client OAuth configuration: %v", err)
+	}
+
+	// Instantiate the default logger and set the desired log level
+	logger := http_client.NewDefaultLogger()
+	logLevel := http_client.LogLevelInfo // Adjust log level as needed
+
+	// Configuration for the jamfpro
+	config := jamfpro.Config{
+		InstanceName:       authConfig.InstanceName,
+		OverrideBaseDomain: authConfig.OverrideBaseDomain,
+		LogLevel:           logLevel,
+		Logger:             logger,
+		ClientID:           authConfig.ClientID,
+		ClientSecret:       authConfig.ClientSecret,
+	}
+
+	// Create a new jamfpro client instance
+	client, err := jamfpro.NewClient(config)
+	if err != nil {
+		log.Fatalf("Failed to create Jamf Pro client: %v", err)
+	}
+
+	profileUDID := "116AF1E6-7EB5-4335-B598-276CDE5EXXXX" // Replace with the actual UDID
+
+	updatedProfile := &jamfpro.ResponseMobileDeviceProvisioningProfile{
+		General: jamfpro.MobileDeviceProvisioningProfileGeneral{
+			Name:        "in-house app profile",
+			DisplayName: "in-house app profile",
+			UUID:        "116AF1E6-7EB5-4335-B598-276CDE5E015B",
+		},
+	}
+
+	profile, err := client.UpdateMobileDeviceProvisioningProfileByUUID(profileUDID, updatedProfile)
+	if err != nil {
+		log.Fatalf("Error updating mobile device provisioning profile by UDID: %v", err)
+	}
+
+	profileXML, err := xml.MarshalIndent(profile, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated profile data: %v", err)
+	}
+	fmt.Println("Updated Mobile Device Provisioning Profile (ByUDID):\n", string(profileXML))
+}

--- a/sdk/http_client/sdk_version.go
+++ b/sdk/http_client/sdk_version.go
@@ -4,7 +4,7 @@ package http_client
 import "fmt"
 
 const (
-	SDKVersion    = "0.0.74"
+	SDKVersion    = "0.0.76"
 	UserAgentBase = "go-jamfpro-api-sdk"
 )
 

--- a/sdk/jamfpro/classicapi_mobile_device_provisioning_profiles.go
+++ b/sdk/jamfpro/classicapi_mobile_device_provisioning_profiles.go
@@ -1,0 +1,300 @@
+// classicapi_mobile_device_provisioning_profiles.go
+// Jamf Pro Classic Api - Mobile Device Provisioning Profiles
+// API reference: https://developer.jamf.com/jamf-pro/reference/mobiledeviceprovisioningprofiles
+// Jamf Pro Classic API requires the structs to support an XML data structure.
+
+package jamfpro
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+const uriMobileDeviceProvisioningProfiles = "/JSSResource/mobiledeviceprovisioningprofiles"
+
+// ResponseMobileDeviceProvisioningProfilesList represents the response for a list of mobile device provisioning profiles.
+type ResponseMobileDeviceProvisioningProfilesList struct {
+	Size                            int                                   `xml:"size"`
+	MobileDeviceProvisioningProfile []MobileDeviceProvisioningProfileItem `xml:"mobile_device_provisioning_profile"`
+}
+
+// MobileDeviceProvisioningProfileItem represents a single mobile device provisioning profile item.
+type MobileDeviceProvisioningProfileItem struct {
+	ID          int    `xml:"id"`
+	Name        string `xml:"name"`
+	DisplayName string `xml:"display_name"`
+	UUID        string `xml:"uuid"`
+}
+
+// ResponseMobileDeviceProvisioningProfile represents the detailed structure for a mobile device provisioning profile.
+type ResponseMobileDeviceProvisioningProfile struct {
+	General MobileDeviceProvisioningProfileGeneral `xml:"general"`
+}
+
+// MobileDeviceProvisioningProfileGeneral contains general information about the provisioning profile.
+type MobileDeviceProvisioningProfileGeneral struct {
+	ID          int    `xml:"id"`
+	Name        string `xml:"name"`
+	DisplayName string `xml:"display_name"`
+	UUID        string `xml:"uuid"`
+}
+
+// GetMobileDeviceProvisioningProfiles retrieves a serialized list of mobile device provisioning profiles.
+func (c *Client) GetMobileDeviceProvisioningProfiles() (*ResponseMobileDeviceProvisioningProfilesList, error) {
+	endpoint := uriMobileDeviceProvisioningProfiles
+
+	var profiles ResponseMobileDeviceProvisioningProfilesList
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profiles)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device provisioning profiles: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profiles, nil
+}
+
+// GetMobileDeviceProvisioningProfileByID fetches a specific mobile device provisioning profile by its ID.
+func (c *Client) GetMobileDeviceProvisioningProfileByID(id int) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceProvisioningProfiles, id)
+
+	var profile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device provisioning profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetMobileDeviceProvisioningProfileByName fetches a specific mobile device provisioning profile by its name.
+func (c *Client) GetMobileDeviceProvisioningProfileByName(name string) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceProvisioningProfiles, name)
+
+	var profile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device provisioning profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// GetMobileDeviceProvisioningProfileByUUID fetches a specific mobile device provisioning profile by its UUID.
+func (c *Client) GetMobileDeviceProvisioningProfileByUUID(uuid string) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/uuid/%s", uriMobileDeviceProvisioningProfiles, uuid)
+
+	var profile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch mobile device provisioning profile by UUID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &profile, nil
+}
+
+// CreateMobileDeviceProvisioningProfileByID creates a new mobile device provisioning profile by its ID.
+func (c *Client) CreateMobileDeviceProvisioningProfileByID(id int, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceProvisioningProfiles, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mobile device provisioning profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// CreateMobileDeviceProvisioningProfileByName creates a new mobile device provisioning profile by its name.
+func (c *Client) CreateMobileDeviceProvisioningProfileByName(name string, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceProvisioningProfiles, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mobile device provisioning profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// CreateMobileDeviceProvisioningProfileByUUID creates a new mobile device provisioning profile by its UUID.
+func (c *Client) CreateMobileDeviceProvisioningProfileByUUID(uuid string, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/uuid/%s", uriMobileDeviceProvisioningProfiles, uuid)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var responseProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("POST", endpoint, &requestBody, &responseProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mobile device provisioning profile by UUID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &responseProfile, nil
+}
+
+// UpdateMobileDeviceProvisioningProfileByID updates a mobile device provisioning profile by its ID.
+func (c *Client) UpdateMobileDeviceProvisioningProfileByID(id int, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceProvisioningProfiles, id)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var updatedProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device provisioning profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedProfile, nil
+}
+
+// UpdateMobileDeviceProvisioningProfileByName updates a mobile device provisioning profile by its name.
+func (c *Client) UpdateMobileDeviceProvisioningProfileByName(name string, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceProvisioningProfiles, name)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var updatedProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device provisioning profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedProfile, nil
+}
+
+// UpdateMobileDeviceProvisioningProfileByUUID updates a mobile device provisioning profile by its UUID.
+func (c *Client) UpdateMobileDeviceProvisioningProfileByUUID(uuid string, profile *ResponseMobileDeviceProvisioningProfile) (*ResponseMobileDeviceProvisioningProfile, error) {
+	endpoint := fmt.Sprintf("%s/uuid/%s", uriMobileDeviceProvisioningProfiles, uuid)
+
+	requestBody := struct {
+		XMLName xml.Name `xml:"mobile_device_provisioning_profile"`
+		*ResponseMobileDeviceProvisioningProfile
+	}{
+		ResponseMobileDeviceProvisioningProfile: profile,
+	}
+
+	var updatedProfile ResponseMobileDeviceProvisioningProfile
+	resp, err := c.HTTP.DoRequest("PUT", endpoint, &requestBody, &updatedProfile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update mobile device provisioning profile by UUID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updatedProfile, nil
+}
+
+// DeleteMobileDeviceProvisioningProfileByID deletes a mobile device provisioning profile by ID
+func (c *Client) DeleteMobileDeviceProvisioningProfileByID(id int) error {
+	endpoint := fmt.Sprintf("%s/id/%d", uriMobileDeviceProvisioningProfiles, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device provisioning profile by ID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteMobileDeviceProvisioningProfileByName deletes a mobile device provisioning profile by Name
+func (c *Client) DeleteMobileDeviceProvisioningProfileByName(name string) error {
+	endpoint := fmt.Sprintf("%s/name/%s", uriMobileDeviceProvisioningProfiles, name)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device provisioning profile by name: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// DeleteMobileDeviceProvisioningProfileByUUID deletes a mobile device provisioning profile by UUID
+func (c *Client) DeleteMobileDeviceProvisioningProfileByUUID(uuid string) error {
+	endpoint := fmt.Sprintf("%s/uuid/%s", uriMobileDeviceProvisioningProfiles, uuid)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete mobile device provisioning profile by UUID: %v", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Jamf Pro Classic API - Mobile Device Provisioning Profiles

This documentation outlines the API endpoints available for managing Mobile Device Provisioning Profiles within Jamf Pro using the Classic API, which supports XML data structures.

## Endpoints

- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles`
  `GetMobileDeviceProvisioningProfiles` retrieves a serialized list of all Mobile Device Provisioning Profiles.

- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
  `GetMobileDeviceProvisioningProfileByID` fetches a specific Mobile Device Provisioning Profile by its ID.

- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
  `GetMobileDeviceProvisioningProfileByName` fetches a specific Mobile Device Provisioning Profile by its name.

- [x] ✅ **GET** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
  `GetMobileDeviceProvisioningProfileByUUID` fetches a specific Mobile Device Provisioning Profile by its UUID.

- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
  `CreateMobileDeviceProvisioningProfileByID` creates a new Mobile Device Provisioning Profile by its ID.

- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
  `CreateMobileDeviceProvisioningProfileByName` creates a new Mobile Device Provisioning Profile by its name.

- [x] ✅ **POST** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
  `CreateMobileDeviceProvisioningProfileByUUID` creates a new Mobile Device Provisioning Profile by its UUID.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
  `UpdateMobileDeviceProvisioningProfileByID` updates an existing Mobile Device Provisioning Profile by its ID.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
  `UpdateMobileDeviceProvisioningProfileByName` updates an existing Mobile Device Provisioning Profile by its name.

- [x] ✅ **PUT** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
  `UpdateMobileDeviceProvisioningProfileByUUID` updates an existing Mobile Device Provisioning Profile by its UUID.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/id/{id}`
  `DeleteMobileDeviceProvisioningProfileByID` deletes a Mobile Device Provisioning Profile by its ID.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/name/{name}`
  `DeleteMobileDeviceProvisioningProfileByName` deletes a Mobile Device Provisioning Profile by its name.

- [x] ✅ **DELETE** `/JSSResource/mobiledeviceprovisioningprofiles/uuid/{uuid}`
  `DeleteMobileDeviceProvisioningProfileByUUID` deletes a Mobile Device Provisioning Profile by its UUID.
