### PR TITLE
Dev

### DIFF
--- a/examples/computer_checkin/UpdateComputerCheckinInformation/UpdateComputerCheckinInformation.go
+++ b/examples/computer_checkin/UpdateComputerCheckinInformation/UpdateComputerCheckinInformation.go
@@ -40,16 +40,16 @@ func main() {
 
 	// Set up new settings
 	newSettings := jamfpro.ResponseComputerCheckin{
-		CheckInFrequency:                 5,
+		CheckInFrequency:                 15, // Values can be 60, 30, 15 and  5
 		CreateStartupScript:              true,
 		LogStartupEvent:                  true,
 		CheckForPoliciesAtStartup:        true,
-		ApplyComputerLevelManagedPrefs:   false,
+		ApplyComputerLevelManagedPrefs:   true,
 		EnsureSSHIsEnabled:               false,
 		CreateLoginLogoutHooks:           true,
 		LogUsername:                      true,
 		CheckForPoliciesAtLoginLogout:    true,
-		ApplyUserLevelManagedPreferences: false,
+		ApplyUserLevelManagedPreferences: true,
 		HideRestorePartition:             false,
 		PerformLoginActionsInBackground:  true,
 		DisplayStatusToUser:              false,

--- a/examples/computers/CreateComputer/CreateComputer.go
+++ b/examples/computers/CreateComputer/CreateComputer.go
@@ -40,9 +40,9 @@ func main() {
 	// Create a new computer configuration
 	newComputer := jamfpro.ResponseComputer{
 		General: jamfpro.General{
-			Name:         "admin’s MacBook Pro",
-			SerialNumber: "C02Q7KHTGFXX",                         // Must be Unique
-			UDID:         "EBBFF74D-C6B7-5589-93A9-19E8BDFEDEXX", // Must be Unique
+			Name:         "MAPGWFYKTF",
+			SerialNumber: "MAPGWFYKTF",                           // Must be Unique
+			UDID:         "MAPFF74D-C6B7-5589-93A9-19E8BDFEDKTF", // Must be Unique
 			RemoteManagement: jamfpro.RemoteManagement{
 				Managed: true,
 			},

--- a/sdk/jamfpro/classicapi_macos_configuration_profiles.go
+++ b/sdk/jamfpro/classicapi_macos_configuration_profiles.go
@@ -64,126 +64,82 @@ type MacOSConfigurationProfilesDataSubsetCategory struct {
 type MacOSConfigurationProfilesDataSubsetScope struct {
 	AllComputers   bool                                                `xml:"all_computers,omitempty"`
 	AllJSSUsers    bool                                                `xml:"all_jss_users,omitempty"`
-	Computers      []MacOSConfigurationProfilesDataSubsetComputer      `xml:"computers,omitempty"`
-	Buildings      []MacOSConfigurationProfilesDataSubsetBuilding      `xml:"buildings,omitempty"`
-	Departments    []MacOSConfigurationProfilesDataSubsetDepartment    `xml:"departments,omitempty"`
-	ComputerGroups []MacOSConfigurationProfilesDataSubsetComputerGroup `xml:"computer_groups,omitempty"`
-	JSSUsers       []MacOSConfigurationProfilesDataSubsetJSSUser       `xml:"jss_users,omitempty"`
-	JSSUserGroups  []MacOSConfigurationProfilesDataSubsetJSSUserGroup  `xml:"jss_user_groups,omitempty"`
+	Computers      []MacOSConfigurationProfilesDataSubsetComputer      `xml:"computers>computer,omitempty"`
+	ComputerGroups []MacOSConfigurationProfilesDataSubsetComputerGroup `xml:"computer_groups>computer_group,omitempty"`
+	JSSUsers       []MacOSConfigurationProfilesDataSubsetJSSUser       `xml:"jss_users>jss_user,omitempty"`
+	JSSUserGroups  []MacOSConfigurationProfilesDataSubsetJSSUserGroup  `xml:"jss_user_groups>jss_user_group,omitempty"`
+	Buildings      []MacOSConfigurationProfilesDataSubsetBuilding      `xml:"buildings>building,omitempty"`
+	Departments    []MacOSConfigurationProfilesDataSubsetDepartment    `xml:"departments>department,omitempty"`
 	Limitations    MacOSConfigurationProfilesDataSubsetLimitations     `xml:"limitations,omitempty"`
 	Exclusions     MacOSConfigurationProfilesDataSubsetExclusions      `xml:"exclusions,omitempty"`
 }
 
 type MacOSConfigurationProfilesDataSubsetComputer struct {
-	Computer MacOSConfigurationProfilesDataSubsetComputerItem `xml:"computer,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetComputerItem struct {
 	ID   int    `xml:"id,omitempty"`
 	Name string `xml:"name,omitempty"`
 	UDID string `xml:"udid,omitempty"`
 }
 
-type MacOSConfigurationProfilesDataSubsetBuilding struct {
-	Building MacOSConfigurationProfilesDataSubsetBuildingItem `xml:"building,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetBuildingItem struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetDepartment struct {
-	Department MacOSConfigurationProfilesDataSubsetDepartmentItem `xml:"department,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetDepartmentItem struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
 type MacOSConfigurationProfilesDataSubsetComputerGroup struct {
-	ComputerGroup MacOSConfigurationProfilesDataSubsetComputerGroupItem `xml:"computer_group,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetComputerGroupItem struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetLimitations struct {
-	Users           []MacOSConfigurationProfilesDataSubsetUser           `xml:"users,omitempty"`
-	UserGroups      []MacOSConfigurationProfilesDataSubsetUserGroup      `xml:"user_groups,omitempty"`
-	NetworkSegments []MacOSConfigurationProfilesDataSubsetNetworkSegment `xml:"network_segments,omitempty"`
-	IBeacons        []MacOSConfigurationProfilesDataSubsetIBeacon        `xml:"ibeacons,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetUser struct {
-	User MacOSConfigurationProfilesDataSubsetUserItem `xml:"user,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetUserItem struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetUserGroup struct {
-	UserGroup MacOSConfigurationProfilesDataSubsetUserGroupItem `xml:"user_group,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetUserGroupItem struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetNetworkSegment struct {
-	NetworkSegment MacOSConfigurationProfilesDataSubsetNetworkSegmentItem `xml:"network_segment,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetNetworkSegmentItem struct {
-	ID   int    `xml:"id,omitempty"`
-	UID  string `xml:"uid,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetIBeacon struct {
-	IBeacon MacOSConfigurationProfilesDataSubsetIBeaconItem `xml:"ibeacon,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetIBeaconItem struct {
 	ID   int    `xml:"id,omitempty"`
 	Name string `xml:"name,omitempty"`
 }
 
 type MacOSConfigurationProfilesDataSubsetJSSUser struct {
-	JSSUser MacOSConfigurationProfilesDataSubsetJSSUserItem `xml:"jss_user,omitempty"`
-}
-
-type MacOSConfigurationProfilesDataSubsetJSSUserItem struct {
 	ID   int    `xml:"id,omitempty"`
 	Name string `xml:"name,omitempty"`
 }
 
 type MacOSConfigurationProfilesDataSubsetJSSUserGroup struct {
-	JSSUserGroup MacOSConfigurationProfilesDataSubsetJSSUserGroupItem `xml:"jss_user_group,omitempty"`
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
 }
 
-type MacOSConfigurationProfilesDataSubsetJSSUserGroupItem struct {
+type MacOSConfigurationProfilesDataSubsetBuilding struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
+type MacOSConfigurationProfilesDataSubsetDepartment struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+type MacOSConfigurationProfilesDataSubsetLimitations struct {
+	Users           []MacOSConfigurationProfilesDataSubsetUser           `xml:"users>user,omitempty"`
+	UserGroups      []MacOSConfigurationProfilesDataSubsetUserGroup      `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []MacOSConfigurationProfilesDataSubsetNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []MacOSConfigurationProfilesDataSubsetIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+}
+type MacOSConfigurationProfilesDataSubsetIBeacon struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+type MacOSConfigurationProfilesDataSubsetNetworkSegment struct {
+	ID   int    `xml:"id,omitempty"`
+	UID  string `xml:"uid,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+type MacOSConfigurationProfilesDataSubsetUserGroup struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
+type MacOSConfigurationProfilesDataSubsetUser struct {
 	ID   int    `xml:"id,omitempty"`
 	Name string `xml:"name,omitempty"`
 }
 
 type MacOSConfigurationProfilesDataSubsetExclusions struct {
 	Computers       []MacOSConfigurationProfilesDataSubsetComputer       `xml:"computers,omitempty"`
-	Buildings       []MacOSConfigurationProfilesDataSubsetBuilding       `xml:"buildings,omitempty"`
-	Departments     []MacOSConfigurationProfilesDataSubsetDepartment     `xml:"departments,omitempty"`
 	ComputerGroups  []MacOSConfigurationProfilesDataSubsetComputerGroup  `xml:"computer_groups,omitempty"`
 	Users           []MacOSConfigurationProfilesDataSubsetUser           `xml:"users,omitempty"`
 	UserGroups      []MacOSConfigurationProfilesDataSubsetUserGroup      `xml:"user_groups,omitempty"`
+	Buildings       []MacOSConfigurationProfilesDataSubsetBuilding       `xml:"buildings,omitempty"`
+	Departments     []MacOSConfigurationProfilesDataSubsetDepartment     `xml:"departments,omitempty"`
 	NetworkSegments []MacOSConfigurationProfilesDataSubsetNetworkSegment `xml:"network_segments,omitempty"`
-	IBeacons        []MacOSConfigurationProfilesDataSubsetIBeacon        `xml:"ibeacons,omitempty"`
 	JSSUsers        []MacOSConfigurationProfilesDataSubsetJSSUser        `xml:"jss_users,omitempty"`
 	JSSUserGroups   []MacOSConfigurationProfilesDataSubsetJSSUserGroup   `xml:"jss_user_groups,omitempty"`
+	IBeacons        []MacOSConfigurationProfilesDataSubsetIBeacon        `xml:"ibeacons,omitempty"`
 }
 
 type MacOSConfigurationProfilesDataSubsetSelfService struct {

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -112,14 +112,20 @@ type PolicySite struct {
 
 // PolicyScope represents the scope of the policy
 type PolicyScope struct {
-	AllComputers   bool                  `xml:"all_computers"`
-	Computers      []PolicyComputer      `xml:"computers>computer,omitempty"`
-	ComputerGroups []PolicyComputerGroup `xml:"computer_groups>computer_group,omitempty"`
-	Buildings      []PolicyBuilding      `xml:"buildings>building,omitempty"`
-	Departments    []PolicyDepartment    `xml:"departments>department,omitempty"`
-	LimitToUsers   PolicyLimitToUsers    `xml:"limit_to_users,omitempty"`
-	Limitations    PolicyLimitations     `xml:"limitations,omitempty"`
-	Exclusions     PolicyExclusions      `xml:"exclusions,omitempty"`
+	AllComputers    bool                   `xml:"all_computers"`
+	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
+	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
+	JSSUsers        []PolicyJSSUser        `xml:"jss_users>jss_user,omitempty"`
+	JSSUserGroups   []PolicyJSSUserGroup   `xml:"jss_user_groups>jss_user_group,omitempty"`
+	Buildings       []PolicyBuilding       `xml:"buildings>building,omitempty"`
+	Departments     []PolicyDepartment     `xml:"departments>department,omitempty"`
+	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	Users           []PolicyUser           `xml:"users>user,omitempty"`
+	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
+	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+	LimitToUsers    PolicyLimitToUsers     `xml:"limit_to_users,omitempty"`
+	Limitations     PolicyLimitations      `xml:"limitations,omitempty"`
+	Exclusions      PolicyExclusions       `xml:"exclusions,omitempty"`
 }
 
 type PolicyComputer struct {
@@ -133,12 +139,42 @@ type PolicyComputerGroup struct {
 	Name string `xml:"name"`
 }
 
+type PolicyJSSUser struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name,omitempty"`
+}
+
+type PolicyJSSUserGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
 type PolicyBuilding struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
 
 type PolicyDepartment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyNetworkSegment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+	UID  string `xml:"uid,omitempty"`
+}
+
+type PolicyUser struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyUserGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyIBeacon struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
@@ -154,27 +190,6 @@ type PolicyLimitations struct {
 	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
 }
 
-type PolicyUser struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
-type PolicyUserGroup struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
-type PolicyNetworkSegment struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-	UID  string `xml:"uid,omitempty"`
-}
-
-type PolicyIBeacon struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
 type PolicyExclusions struct {
 	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
 	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
@@ -184,6 +199,8 @@ type PolicyExclusions struct {
 	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
 	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
 	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+	JSSUsers        []PolicyJSSUser        `xml:"jss_users>jss_user,omitempty"`
+	JSSUserGroups   []PolicyJSSUserGroup   `xml:"jss_user_groups>jss_user_group,omitempty"`
 }
 
 // PolicySelfService represents the self service settings of a policy

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -112,70 +112,45 @@ type PolicySite struct {
 
 // PolicyScope represents the scope of the policy
 type PolicyScope struct {
-	AllComputers    bool                   `xml:"all_computers"`
-	AllJSSUSers     bool                   `xml:"all_jss_users"`
-	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
-	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
-	JSSUsers        []PolicyJSSUser        `xml:"jss_users>jss_user,omitempty"`
-	JSSUserGroups   []PolicyJSSUserGroup   `xml:"jss_user_groups>jss_user_group,omitempty"`
-	Buildings       []PolicyBuilding       `xml:"buildings>building,omitempty"`
-	Departments     []PolicyDepartment     `xml:"departments>department,omitempty"`
-	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
-	Users           []PolicyUser           `xml:"users>user,omitempty"`
-	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
-	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
-	LimitToUsers    PolicyLimitToUsers     `xml:"limit_to_users,omitempty"`
-	Limitations     PolicyLimitations      `xml:"limitations,omitempty"`
-	Exclusions      PolicyExclusions       `xml:"exclusions,omitempty"`
+	AllComputers   bool                            `xml:"all_computers"`
+	AllJSSUSers    bool                            `xml:"all_jss_users"`
+	Computers      []PolicyDataSubsetComputer      `xml:"computers>computer,omitempty"`
+	ComputerGroups []PolicyDataSubsetComputerGroup `xml:"computer_groups>computer_group,omitempty"`
+	JSSUsers       []PolicyDataSubsetJSSUser       `xml:"jss_users>jss_user,omitempty"`
+	JSSUserGroups  []PolicyDataSubsetJSSUserGroup  `xml:"jss_user_groups>jss_user_group,omitempty"`
+	Buildings      []PolicyDataSubsetBuilding      `xml:"buildings>building,omitempty"`
+	Departments    []PolicyDataSubsetDepartment    `xml:"departments>department,omitempty"`
+	LimitToUsers   PolicyLimitToUsers              `xml:"limit_to_users,omitempty"`
+	Limitations    PolicyLimitations               `xml:"limitations,omitempty"`
+	Exclusions     PolicyExclusions                `xml:"exclusions,omitempty"`
 }
 
-type PolicyComputer struct {
+type PolicyDataSubsetComputer struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name,omitempty"`
 	UDID string `xml:"udid,omitempty"`
 }
 
-type PolicyComputerGroup struct {
+type PolicyDataSubsetComputerGroup struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
 
-type PolicyJSSUser struct {
+type PolicyDataSubsetJSSUser struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name,omitempty"`
 }
 
-type PolicyJSSUserGroup struct {
+type PolicyDataSubsetJSSUserGroup struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
-type PolicyBuilding struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
-type PolicyDepartment struct {
+type PolicyDataSubsetBuilding struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
 
-type PolicyNetworkSegment struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-	UID  string `xml:"uid,omitempty"`
-}
-
-type PolicyUser struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
-type PolicyUserGroup struct {
-	ID   int    `xml:"id"`
-	Name string `xml:"name"`
-}
-
-type PolicyIBeacon struct {
+type PolicyDataSubsetDepartment struct {
 	ID   int    `xml:"id"`
 	Name string `xml:"name"`
 }
@@ -185,23 +160,44 @@ type PolicyLimitToUsers struct {
 }
 
 type PolicyLimitations struct {
-	Users           []PolicyUser           `xml:"users>user,omitempty"`
-	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
-	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
-	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+	Users           []PolicyDataSubsetUser           `xml:"users>user,omitempty"`
+	UserGroups      []PolicyDataSubsetUserGroup      `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []PolicyDataSubsetNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []PolicyDataSubsetIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
+}
+
+type PolicyDataSubsetUser struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyDataSubsetUserGroup struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type PolicyDataSubsetNetworkSegment struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+	UID  string `xml:"uid,omitempty"`
+}
+
+type PolicyDataSubsetIBeacon struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
 }
 
 type PolicyExclusions struct {
-	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
-	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
-	Buildings       []PolicyBuilding       `xml:"buildings>building,omitempty"`
-	Departments     []PolicyDepartment     `xml:"departments>department,omitempty"`
-	Users           []PolicyUser           `xml:"users>user,omitempty"`
-	UserGroups      []PolicyUserGroup      `xml:"user_groups>user_group,omitempty"`
-	NetworkSegments []PolicyNetworkSegment `xml:"network_segments>network_segment,omitempty"`
-	IBeacons        []PolicyIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
-	JSSUsers        []PolicyJSSUser        `xml:"jss_users>jss_user,omitempty"`
-	JSSUserGroups   []PolicyJSSUserGroup   `xml:"jss_user_groups>jss_user_group,omitempty"`
+	Computers       []PolicyDataSubsetComputer       `xml:"computers>computer,omitempty"`
+	ComputerGroups  []PolicyDataSubsetComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
+	Users           []PolicyDataSubsetUser           `xml:"users>user,omitempty"`
+	UserGroups      []PolicyDataSubsetUserGroup      `xml:"user_groups>user_group,omitempty"`
+	Buildings       []PolicyDataSubsetBuilding       `xml:"buildings>building,omitempty"`
+	Departments     []PolicyDataSubsetDepartment     `xml:"departments>department,omitempty"`
+	NetworkSegments []PolicyDataSubsetNetworkSegment `xml:"network_segments>network_segment,omitempty"`
+	JSSUsers        []PolicyDataSubsetJSSUser        `xml:"jss_users>jss_user,omitempty"`
+	JSSUserGroups   []PolicyDataSubsetJSSUserGroup   `xml:"jss_user_groups>jss_user_group,omitempty"`
+	IBeacons        []PolicyDataSubsetIBeacon        `xml:"ibeacons>ibeacon,omitempty"`
 }
 
 // PolicySelfService represents the self service settings of a policy

--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -113,6 +113,7 @@ type PolicySite struct {
 // PolicyScope represents the scope of the policy
 type PolicyScope struct {
 	AllComputers    bool                   `xml:"all_computers"`
+	AllJSSUSers     bool                   `xml:"all_jss_users"`
 	Computers       []PolicyComputer       `xml:"computers>computer,omitempty"`
 	ComputerGroups  []PolicyComputerGroup  `xml:"computer_groups>computer_group,omitempty"`
 	JSSUsers        []PolicyJSSUser        `xml:"jss_users>jss_user,omitempty"`


### PR DESCRIPTION
# Change

Fixed structs for policies. jamf documentation was incorrect and missed out a number of fields. which is what the structs were originally modelled upon. however when comaring the structs to macos config profiles there is clearly some mistakes. so aligned to the correct struct pattern.

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

