### PR TITLE
policy category struct filed bug fix

### DIFF
--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -75,7 +75,7 @@ type PolicyGeneral struct {
 }
 
 type PolicyCategory struct {
-	ID        string `xml:"id,omitempty"`
+	ID        int    `xml:"id,omitempty"`
 	Name      string `xml:"name,omitempty"`
 	DisplayIn bool   `xml:"display_in,omitempty"`
 	FeatureIn bool   `xml:"feature_in,omitempty"`


### PR DESCRIPTION
# Change

filed type bug fix for classicapi_policy.go

type PolicyCategory struct {
	ID        int    `xml:"id,omitempty"`
	Name      string `xml:"name,omitempty"`
	DisplayIn bool   `xml:"display_in,omitempty"`
	FeatureIn bool   `xml:"feature_in,omitempty"`
}

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
