### PR TITLE
Support for attributes not listed in api documentation of osxconfigrationprofile

### DIFF
--- a/sdk/jamfpro/classicapi_macos_configuration_profiles.go
+++ b/sdk/jamfpro/classicapi_macos_configuration_profiles.go
@@ -80,15 +80,19 @@ type MacOSConfigurationProfileSubsetScope struct {
 }
 
 type MacOSConfigurationProfileSubsetSelfService struct {
-	InstallButtonText           string                                               `xml:"install_button_text,omitempty"`
-	SelfServiceDescription      string                                               `xml:"self_service_description,omitempty"`
-	ForceUsersToViewDescription bool                                                 `xml:"force_users_to_view_description"`
-	SelfServiceIcon             SharedResourceSelfServiceIcon                        `xml:"self_service_icon,omitempty"`
-	FeatureOnMainPage           bool                                                 `xml:"feature_on_main_page"`
-	SelfServiceCategories       []MacOSConfigurationProfileSubsetSelfServiceCategory `xml:"self_service_categories>category,omitempty"`
-	Notification                []string                                             `xml:"notification,omitempty"`
-	NotificationSubject         string                                               `xml:"notification_subject,omitempty"`
-	NotificationMessage         string                                               `xml:"notification_message,omitempty"`
+	InstallButtonText           string `xml:"install_button_text,omitempty"`
+	SelfServiceDescription      string `xml:"self_service_description,omitempty"`
+	ForceUsersToViewDescription bool   `xml:"force_users_to_view_description"`
+	// The 'security' filed is not documented, but it actually exists in the API response.
+	Security        MacOSConfigurationProfileSubsetSelfServiceSecurity `xml:"security,omitempty"`
+	SelfServiceIcon SharedResourceSelfServiceIcon                      `xml:"self_service_icon,omitempty"`
+	// The 'self_service_display_name' filed is not documented, but it actually exists in the API response.
+	SelfServiceDisplayName string                                               `xml:"self_service_display_name,omitempty"`
+	FeatureOnMainPage      bool                                                 `xml:"feature_on_main_page"`
+	SelfServiceCategories  []MacOSConfigurationProfileSubsetSelfServiceCategory `xml:"self_service_categories>category,omitempty"`
+	Notification           []string                                             `xml:"notification,omitempty"`
+	NotificationSubject    string                                               `xml:"notification_subject,omitempty"`
+	NotificationMessage    string                                               `xml:"notification_message,omitempty"`
 }
 
 type MacOSConfigurationProfileSubsetSelfServiceCategory struct {
@@ -96,6 +100,10 @@ type MacOSConfigurationProfileSubsetSelfServiceCategory struct {
 	Name      string `xml:"name,omitempty"`
 	DisplayIn bool   `xml:"display_in,omitempty"`
 	FeatureIn bool   `xml:"feature_in,omitempty"`
+}
+
+type MacOSConfigurationProfileSubsetSelfServiceSecurity struct {
+	RemovalDisallowed string `xml:"removal_disallowed,omitempty"`
 }
 
 type MacOSConfigurationProfileSubsetComputer struct {


### PR DESCRIPTION
# Change

Support for attributes that have no value but can be used in OSXConfigurationProfile API endpoints that are not listed in the official documentation.

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <os_x_configuration_profile>
    ...
    <self_service>
      <self_service_display_name>sample</self_service_display_name>
      <install_button_text>Install</install_button_text>
      <self_service_description/>
      <force_users_to_view_description>false</force_users_to_view_description>
      <security>
        <removal_disallowed>Never</removal_disallowed>
      </security>
      <self_service_icon/>
      <feature_on_main_page>false</feature_on_main_page>
      <self_service_categories/>
      <notification>false</notification>
      <notification>Self Service</notification>
      <notification_subject>tonishi-test-5</notification_subject>
      <notification_message>message-5</notification_message>
    </self_service>
    ...
 </os_x_configuration_profile>
```

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
