### PR TITLE
fix: actually pass `sort_filter` to `DoPaginatedGet` in `GetComputersInventory`

### DIFF
--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -538,7 +538,7 @@ func (c *Client) GetComputersInventory(sort_filter string) (*ResponseComputerInv
 		uriComputersInventory,
 		standardPageSize,
 		startingPageNumber,
-		"",
+		sort_filter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computers-inventories", err)


### PR DESCRIPTION
# Change

The `sort_filter` parameter was not passed to `DoPaginatedGet`, so it did nothing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
