### PR TITLE
fix: Add FlushSoftwareUpdatePlans to jamfproapi_enrollment_settings.go

### DIFF
--- a/sdk/jamfpro/jamfproapi_enrollment_settings.go
+++ b/sdk/jamfpro/jamfproapi_enrollment_settings.go
@@ -28,6 +28,7 @@ type EnrollmentSubsetCertificateSettings struct {
 	FlushLocationHistoryInformation     bool                               `json:"flushLocationHistoryInformation"`
 	FlushPolicyHistory                  bool                               `json:"flushPolicyHistory"`
 	FlushExtensionAttributes            bool                               `json:"flushExtensionAttributes"`
+	FlushSoftwareUpdatePlans            bool                               `json:"flushSoftwareUpdatePlans"`
 	FlushMdmCommandsOnReenroll          string                             `json:"flushMdmCommandsOnReenroll"`
 	MacOsEnterpriseEnrollmentEnabled    bool                               `json:"macOsEnterpriseEnrollmentEnabled"`
 	ManagementUsername                  string                             `json:"managementUsername"`


### PR DESCRIPTION
# Change

This should ensure proper state detection of `flush_software_update_plans` and stop the `jamfpro_user_initiated_enrollment_settings` resource trying to update on every run despite already being set to `true` by the resource in the Jamf Pro instance.

Otherwise we see the following on every `terraform plan` or `terraform apply` run.

```
  # module.settings-userinitiatedenrollment.jamfpro_user_initiated_enrollment_settings.user_initiated_enrollment_settings will be updated in-place
  ~ resource "jamfpro_user_initiated_enrollment_settings" "user_initiated_enrollment_settings" {
      ~ flush_software_update_plans                     = false -> true
        id                                              = "jamfpro_user_initiated_enrollment_settings_singleton"
        # (8 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }
```

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
