### PR TITLE
feat!: Pagination func filter passing refactored

### DIFF
--- a/docs/url_queries.md
+++ b/docs/url_queries.md
@@ -1,0 +1,77 @@
+# Querying the Jamf Pro API with RSQL
+
+Jamf Pro's **Jamf Pro API (v1+)** supports querying resources using **RSQL filters** via HTTP requests. This guide explains how to construct API queries using URLs with RSQL in Go.
+
+
+## 📘 Basic URL Format
+
+Jamf Pro API endpoints follow this pattern:
+
+```
+https://<jamf-host>/api/<resource-path>?page=0&page-size=50&sort=fieldName:asc&filter=<rsql-expression>
+```
+
+- `page`: zero-based page index.
+- `page-size`: number of results per page.
+- `sort`: optional; `fieldName:asc` or `fieldName:desc`.
+- `filter`: your RSQL query string (URL-encoded).
+
+---
+
+## 🔍 Example: Query Computers by Name
+
+**Goal:** Find all computers whose name contains `test`.
+
+**Endpoint:**
+
+```
+GET /api/v1/computers-inventory
+```
+
+**RSQL Filter:**
+
+```
+general.name==*test*
+```
+
+**Full URL (URL-encoded):**
+
+```
+https://your-jamf-url.com/api/v1/computers-inventory?filter=general.name%3D%3D%2Atest%2A
+```
+
+
+
+## 🧑‍💻 Creating an RSQL Query using `url.Values{}` in Go
+
+```go
+import (
+	"net/http"
+	"net/url"
+)
+
+func buildJamfQuery() (*http.Request, error) {
+	baseURL := "https://your-jamf-url.com/api/v1/computers-inventory"
+
+	params := url.Values{}
+	params.Set("page", "0")
+	params.Set("page-size", "50")
+	params.Set("sort", "general.name:asc")
+	params.Set("filter", `general.name==*test*`)
+
+	fullURL := baseURL + "?" + params.Encode()
+
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer YOUR_API_TOKEN")
+	return req, nil
+}
+```
+
+- `url.Values{}.Encode()` handles correct URL encoding for you.
+- The RSQL filter will be encoded automatically (e.g. `==` → `%3D%3D`, `*` → `%2A`).
+
+---

--- a/examples/bookmarks/GetBookmarks/GetBookmarks.go
+++ b/examples/bookmarks/GetBookmarks/GetBookmarks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call function
-	bookmarksList, err := client.GetBookmarks("")
+	bookmarksList, err := client.GetBookmarks(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching accounts: %v", err)
 	}

--- a/examples/bookmarks/GetBookmarks/GetBookmarks.go
+++ b/examples/bookmarks/GetBookmarks/GetBookmarks.go
@@ -19,6 +19,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
+	// For more information on how to add parameters to this request, see docs/url_queries.md
+
 	// Call function
 	bookmarksList, err := client.GetBookmarks(url.Values{})
 	if err != nil {

--- a/examples/buildings/GetBuildingResourceHistoryByID/GetBuildingResourceHistoryByID.go
+++ b/examples/buildings/GetBuildingResourceHistoryByID/GetBuildingResourceHistoryByID.go
@@ -19,6 +19,7 @@ func main() {
 	}
 
 	// Example: Fetch the resource history of a building by ID
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	buildingID := "" // Replace with a real building ID
 	history, err := client.GetBuildingResourceHistoryByID(buildingID, url.Values{})
 	if err != nil {

--- a/examples/buildings/GetBuildingResourceHistoryByID/GetBuildingResourceHistoryByID.go
+++ b/examples/buildings/GetBuildingResourceHistoryByID/GetBuildingResourceHistoryByID.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 
 	// Example: Fetch the resource history of a building by ID
 	buildingID := "" // Replace with a real building ID
-	history, err := client.GetBuildingResourceHistoryByID(buildingID, "")
+	history, err := client.GetBuildingResourceHistoryByID(buildingID, url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching building resource history: %v", err)
 	}

--- a/examples/buildings/GetBuildings/GetBuildings.go
+++ b/examples/buildings/GetBuildings/GetBuildings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetBuildings function
-	accountsList, err := client.GetBuildings("")
+	accountsList, err := client.GetBuildings(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching accounts: %v", err)
 	}

--- a/examples/buildings/GetBuildings/GetBuildings.go
+++ b/examples/buildings/GetBuildings/GetBuildings.go
@@ -19,6 +19,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
+	// For more information on how to add parameters to this request, see docs/url_queries.md
+
 	// Call GetBuildings function
 	accountsList, err := client.GetBuildings(url.Values{})
 	if err != nil {

--- a/examples/categories/GetCategories/GetCategories.go
+++ b/examples/categories/GetCategories/GetCategories.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 	// Define the sort and filter query parameters
 	// none
 	// Call the GetCategories function
-	categories, err := client.GetCategories("") // Will return all results by default
+	categories, err := client.GetCategories(url.Values{}) // Will return all results by default
 	if err != nil {
 		fmt.Printf("Error fetching categories: %v\n", err)
 		return

--- a/examples/categories/GetCategories/GetCategories.go
+++ b/examples/categories/GetCategories/GetCategories.go
@@ -19,7 +19,8 @@ func main() {
 	}
 
 	// Define the sort and filter query parameters
-	// none
+	// For more information on how to add parameters to this request, see docs/url_queries.md
+
 	// Call the GetCategories function
 	categories, err := client.GetCategories(url.Values{}) // Will return all results by default
 	if err != nil {

--- a/examples/cloud_idp/GetCloudIdentityProviders/GetCloudIdentityProviders.go
+++ b/examples/cloud_idp/GetCloudIdentityProviders/GetCloudIdentityProviders.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Optional: Define sort filter (e.g., "id:asc" or "displayName:desc")
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 
 	// Call GetCloudIdentityProviders function

--- a/examples/cloud_idp/GetCloudIdentityProviders/GetCloudIdentityProviders.go
+++ b/examples/cloud_idp/GetCloudIdentityProviders/GetCloudIdentityProviders.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,10 @@ func main() {
 	}
 
 	// Optional: Define sort filter (e.g., "id:asc" or "displayName:desc")
-	sortFilter := "id:desc"
+	params := url.Values{}
 
 	// Call GetCloudIdentityProviders function
-	cloudIdps, err := client.GetCloudIdentityProviders(sortFilter)
+	cloudIdps, err := client.GetCloudIdentityProviders(params)
 	if err != nil {
 		log.Fatalf("Error fetching cloud identity providers: %v", err)
 	}

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetComputerExtensionAttributes function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	attributes, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Computer Extension Attributes: %v", err)

--- a/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
+++ b/examples/computer_extension_attributes/GetComputerExtensionAttributes/GetComputerExtensionAttributes.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetComputerExtensionAttributes function
-	attributes, err := client.GetComputerExtensionAttributes("")
+	attributes, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Computer Extension Attributes: %v", err)
 	}

--- a/examples/computer_inventory/GetComputersFileVaultInventory/GetComputersFileVaultInventory.go
+++ b/examples/computer_inventory/GetComputersFileVaultInventory/GetComputersFileVaultInventory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,11 @@ func main() {
 	}
 
 	// Sort filter
-	sortFilter := "sort=id:desc"
+	params := url.Values{}
+	params.Add("sort", "id:desc")
 
 	// Call the GetComputersFileVaultInventory function
-	fileVaultInventory, err := client.GetComputersFileVaultInventory(sortFilter)
+	fileVaultInventory, err := client.GetComputersFileVaultInventory(params)
 	if err != nil {
 		log.Fatalf("Error fetching FileVault inventory: %v", err)
 	}

--- a/examples/computer_inventory/GetComputersFileVaultInventory/GetComputersFileVaultInventory.go
+++ b/examples/computer_inventory/GetComputersFileVaultInventory/GetComputersFileVaultInventory.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Sort filter
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 	params.Add("sort", "id:desc")
 

--- a/examples/computer_inventory/GetComputersInventory/GetComputersInventory.go
+++ b/examples/computer_inventory/GetComputersInventory/GetComputersInventory.go
@@ -37,6 +37,7 @@ func main() {
 	// sections := []string{"GENERAL", "DISK_ENCRYPTION", "STORAGE"} // Example sections
 
 	// Call the GetComputersInventory function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	inventoryList, err := client.GetComputersInventory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer inventory: %v", err)

--- a/examples/computer_inventory/GetComputersInventory/GetComputersInventory.go
+++ b/examples/computer_inventory/GetComputersInventory/GetComputersInventory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -36,7 +37,7 @@ func main() {
 	// sections := []string{"GENERAL", "DISK_ENCRYPTION", "STORAGE"} // Example sections
 
 	// Call the GetComputersInventory function
-	inventoryList, err := client.GetComputersInventory("")
+	inventoryList, err := client.GetComputersInventory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer inventory: %v", err)
 	}

--- a/examples/computer_prestages/GetComputerPrestages/GetComputerPrestages.go
+++ b/examples/computer_prestages/GetComputerPrestages/GetComputerPrestages.go
@@ -20,7 +20,8 @@ func main() {
 	}
 
 	// Define sorting parameters
-	params := url.Values{} // Example: "name" for sorting by name
+	// For more information on how to add parameters to this request, see docs/url_queries.md
+	params := url.Values{}
 	params.Add("sort", "name")
 
 	// Fetch computer prestages using the V3 API

--- a/examples/computer_prestages/GetComputerPrestages/GetComputerPrestages.go
+++ b/examples/computer_prestages/GetComputerPrestages/GetComputerPrestages.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,11 @@ func main() {
 	}
 
 	// Define sorting parameters
-	sortFilter := "name" // Example: "name" for sorting by name
+	params := url.Values{} // Example: "name" for sorting by name
+	params.Add("sort", "name")
 
 	// Fetch computer prestages using the V3 API
-	prestages, err := client.GetComputerPrestages(sortFilter)
+	prestages, err := client.GetComputerPrestages(params)
 	if err != nil {
 		log.Fatalf("Error fetching computer prestages: %v", err)
 	}

--- a/examples/departments/DeleteAllDepartments/DeleteAllDepartments.go
+++ b/examples/departments/DeleteAllDepartments/DeleteAllDepartments.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -18,7 +19,7 @@ func main() {
 	}
 
 	// Fetch all departments
-	departments, err := client.GetDepartments("")
+	departments, err := client.GetDepartments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching departments: %v", err)
 	}

--- a/examples/departments/DeleteAllDepartments/DeleteAllDepartments.go
+++ b/examples/departments/DeleteAllDepartments/DeleteAllDepartments.go
@@ -19,6 +19,7 @@ func main() {
 	}
 
 	// Fetch all departments
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	departments, err := client.GetDepartments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching departments: %v", err)

--- a/examples/departments/GetDepartments/GetDepartments.go
+++ b/examples/departments/GetDepartments/GetDepartments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetDepartments function
-	departments, err := client.GetDepartments("")
+	departments, err := client.GetDepartments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching departments: %v", err)
 	}

--- a/examples/departments/GetDepartments/GetDepartments.go
+++ b/examples/departments/GetDepartments/GetDepartments.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetDepartments function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	departments, err := client.GetDepartments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching departments: %v", err)

--- a/examples/device_enrollments/GetDeviceEnrollmentHistory/GetDeviceEnrollmentHistory.go
+++ b/examples/device_enrollments/GetDeviceEnrollmentHistory/GetDeviceEnrollmentHistory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 
 	// Fetch Device Enrollment History
 	deviceEnrollmentID := "1" // Using the known device enrollment ID from the system
-	response, err := client.GetDeviceEnrollmentHistory(deviceEnrollmentID, "")
+	response, err := client.GetDeviceEnrollmentHistory(deviceEnrollmentID, url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching device enrollment history: %v", err)
 	}

--- a/examples/device_enrollments/GetDeviceEnrollmentHistory/GetDeviceEnrollmentHistory.go
+++ b/examples/device_enrollments/GetDeviceEnrollmentHistory/GetDeviceEnrollmentHistory.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Fetch Device Enrollment History
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	deviceEnrollmentID := "1" // Using the known device enrollment ID from the system
 	response, err := client.GetDeviceEnrollmentHistory(deviceEnrollmentID, url.Values{})
 	if err != nil {

--- a/examples/device_enrollments/GetDeviceEnrollments/GetDeviceEnrollments.go
+++ b/examples/device_enrollments/GetDeviceEnrollments/GetDeviceEnrollments.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Fetch Device Enrollments
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	response, err := client.GetDeviceEnrollments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Device enrollment instances: %v", err)

--- a/examples/device_enrollments/GetDeviceEnrollments/GetDeviceEnrollments.go
+++ b/examples/device_enrollments/GetDeviceEnrollments/GetDeviceEnrollments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Fetch Device Enrollments
-	response, err := client.GetDeviceEnrollments("")
+	response, err := client.GetDeviceEnrollments(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Device enrollment instances: %v", err)
 	}

--- a/examples/enrollment/GetAccountDrivenUserEnrollmentAccessGroups/GetAccountDrivenUserEnrollmentAccessGroups.go
+++ b/examples/enrollment/GetAccountDrivenUserEnrollmentAccessGroups/GetAccountDrivenUserEnrollmentAccessGroups.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetAccountDrivenUserEnrollmentAccessGroups function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	ADUEAccessGroups, err := client.GetAccountDrivenUserEnrollmentAccessGroups(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching ADUE Access Groups: %v", err)

--- a/examples/enrollment/GetAccountDrivenUserEnrollmentAccessGroups/GetAccountDrivenUserEnrollmentAccessGroups.go
+++ b/examples/enrollment/GetAccountDrivenUserEnrollmentAccessGroups/GetAccountDrivenUserEnrollmentAccessGroups.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetAccountDrivenUserEnrollmentAccessGroups function
-	ADUEAccessGroups, err := client.GetAccountDrivenUserEnrollmentAccessGroups("")
+	ADUEAccessGroups, err := client.GetAccountDrivenUserEnrollmentAccessGroups(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching ADUE Access Groups: %v", err)
 	}

--- a/examples/enrollment/GetEnrollmentHistory/GetEnrollmentHistory.go
+++ b/examples/enrollment/GetEnrollmentHistory/GetEnrollmentHistory.go
@@ -21,6 +21,7 @@ func main() {
 
 	// Call GetEnrollmentHistory function
 	// You can add sorting parameters like "sort=date:desc" to sort by date in descending order
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	history, err := client.GetEnrollmentHistory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error getting enrollment history: %v", err)

--- a/examples/enrollment/GetEnrollmentHistory/GetEnrollmentHistory.go
+++ b/examples/enrollment/GetEnrollmentHistory/GetEnrollmentHistory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 
 	// Call GetEnrollmentHistory function
 	// You can add sorting parameters like "sort=date:desc" to sort by date in descending order
-	history, err := client.GetEnrollmentHistory("")
+	history, err := client.GetEnrollmentHistory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error getting enrollment history: %v", err)
 	}

--- a/examples/enrollment_customizations/GetEnrollmentCustomizations/GetEnrollmentCustomizations.go
+++ b/examples/enrollment_customizations/GetEnrollmentCustomizations/GetEnrollmentCustomizations.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Get all enrollment customizations
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	customizations, err := client.GetEnrollmentCustomizations(url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to get enrollment customizations: %v", err)

--- a/examples/enrollment_customizations/GetEnrollmentCustomizations/GetEnrollmentCustomizations.go
+++ b/examples/enrollment_customizations/GetEnrollmentCustomizations/GetEnrollmentCustomizations.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -18,13 +19,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
-	// Optional: Define sort and filter parameters
-	// Example: sort=displayName:asc
-	// Leave empty string "" for no sorting/filtering
-	sortFilter := ""
-
 	// Get all enrollment customizations
-	customizations, err := client.GetEnrollmentCustomizations(sortFilter)
+	customizations, err := client.GetEnrollmentCustomizations(url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to get enrollment customizations: %v", err)
 	}

--- a/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
+++ b/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetApiIntegrations function
-	response, err := client.GetApiIntegrations("")
+	response, err := client.GetApiIntegrations(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API Integrations: %v", err)
 	}

--- a/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
+++ b/examples/jamf_api_integrations/GetApiIntegrations/GetApiIntegrations.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetApiIntegrations function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	response, err := client.GetApiIntegrations(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API Integrations: %v", err)

--- a/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
+++ b/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Fetch API roles
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	apiRoles, err := client.GetJamfAPIRoles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API roles: %v", err)

--- a/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
+++ b/examples/jamf_api_roles/GetJamfAPIRoles/GetJamfAPIRoles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Fetch API roles
-	apiRoles, err := client.GetJamfAPIRoles("")
+	apiRoles, err := client.GetJamfAPIRoles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API roles: %v", err)
 	}

--- a/examples/jamf_app_catalog_app_installers/GetJamfAppCatalogAppInstallerTitles/GetJamfAppCatalogAppInstallerTitles.go
+++ b/examples/jamf_app_catalog_app_installers/GetJamfAppCatalogAppInstallerTitles/GetJamfAppCatalogAppInstallerTitles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetJamfAppCatalogAppInstallerTitles function
-	appInstallers, err := client.GetJamfAppCatalogAppInstallerTitles("")
+	appInstallers, err := client.GetJamfAppCatalogAppInstallerTitles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Jamf App Catalog App Installer list: %v", err)
 	}

--- a/examples/jamf_app_catalog_app_installers/GetJamfAppCatalogAppInstallerTitles/GetJamfAppCatalogAppInstallerTitles.go
+++ b/examples/jamf_app_catalog_app_installers/GetJamfAppCatalogAppInstallerTitles/GetJamfAppCatalogAppInstallerTitles.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetJamfAppCatalogAppInstallerTitles function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	appInstallers, err := client.GetJamfAppCatalogAppInstallerTitles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Jamf App Catalog App Installer list: %v", err)

--- a/examples/jamf_connect/GetJamfConnectConfigProfiles/GetJamfConnectConfigProfiles.go
+++ b/examples/jamf_connect/GetJamfConnectConfigProfiles/GetJamfConnectConfigProfiles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 
 	// Call GetJamfConnectConfigProfiles function to fetch profiles
 	// You can provide sort parameters like "status:asc,updated:desc" or leave empty "" for default sorting
-	profiles, err := client.GetJamfConnectConfigProfiles("")
+	profiles, err := client.GetJamfConnectConfigProfiles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Jamf Connect config profiles: %v", err)
 	}

--- a/examples/jamf_connect/GetJamfConnectConfigProfiles/GetJamfConnectConfigProfiles.go
+++ b/examples/jamf_connect/GetJamfConnectConfigProfiles/GetJamfConnectConfigProfiles.go
@@ -20,7 +20,7 @@ func main() {
 	}
 
 	// Call GetJamfConnectConfigProfiles function to fetch profiles
-	// You can provide sort parameters like "status:asc,updated:desc" or leave empty "" for default sorting
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	profiles, err := client.GetJamfConnectConfigProfiles(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Jamf Connect config profiles: %v", err)

--- a/examples/jamf_protect/GetJamfProtectHistory/GetJamfProtectHistory.go
+++ b/examples/jamf_protect/GetJamfProtectHistory/GetJamfProtectHistory.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Define a sort filter (you can modify this as needed)
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 	params.Add("sort", "date:desc")
 

--- a/examples/jamf_protect/GetJamfProtectHistory/GetJamfProtectHistory.go
+++ b/examples/jamf_protect/GetJamfProtectHistory/GetJamfProtectHistory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,11 @@ func main() {
 	}
 
 	// Define a sort filter (you can modify this as needed)
-	sortFilter := "sort=date:desc"
+	params := url.Values{}
+	params.Add("sort", "date:desc")
 
 	// Call GetJamfProtectHistory function
-	history, err := client.GetJamfProtectHistory(sortFilter)
+	history, err := client.GetJamfProtectHistory(params)
 	if err != nil {
 		log.Fatalf("Error fetching Jamf Protect history: %v", err)
 	}

--- a/examples/jamf_protect/GetJamfProtectPlans/GetJamfProtectPlans.go
+++ b/examples/jamf_protect/GetJamfProtectPlans/GetJamfProtectPlans.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Define a sort filter (you can modify this as needed)
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 	params.Add("sort", "name:asc")
 

--- a/examples/jamf_protect/GetJamfProtectPlans/GetJamfProtectPlans.go
+++ b/examples/jamf_protect/GetJamfProtectPlans/GetJamfProtectPlans.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,11 @@ func main() {
 	}
 
 	// Define a sort filter (you can modify this as needed)
-	sortFilter := "sort=name:asc"
+	params := url.Values{}
+	params.Add("sort", "name:asc")
 
 	// Call GetJamfProtectPlans function
-	plans, err := client.GetJamfProtectPlans(sortFilter)
+	plans, err := client.GetJamfProtectPlans(params)
 	if err != nil {
 		log.Fatalf("Error fetching Jamf Protect plans: %v", err)
 	}

--- a/examples/jamf_protect/SyncJamfProtectPlans/SyncJamfProtectPlans.go
+++ b/examples/jamf_protect/SyncJamfProtectPlans/SyncJamfProtectPlans.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -28,7 +29,7 @@ func main() {
 
 	// Optional: You could add additional operations here, such as fetching and displaying the synced plans
 	// For example:
-	plans, err := client.GetJamfProtectPlans("")
+	plans, err := client.GetJamfProtectPlans(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching Jamf Protect plans: %v", err)
 	}

--- a/examples/jamf_protect/SyncJamfProtectPlans/SyncJamfProtectPlans.go
+++ b/examples/jamf_protect/SyncJamfProtectPlans/SyncJamfProtectPlans.go
@@ -28,6 +28,7 @@ func main() {
 	fmt.Println("Jamf Protect plans synced successfully")
 
 	// Optional: You could add additional operations here, such as fetching and displaying the synced plans
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	// For example:
 	plans, err := client.GetJamfProtectPlans(url.Values{})
 	if err != nil {

--- a/examples/managed_software_updates/GetManagedSoftwareUpdatePlans/GetManagedSoftwareUpdatePlans.go
+++ b/examples/managed_software_updates/GetManagedSoftwareUpdatePlans/GetManagedSoftwareUpdatePlans.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetManagedSoftwareUpdatePlans function
-	updatePlans, err := client.GetManagedSoftwareUpdatePlans("")
+	updatePlans, err := client.GetManagedSoftwareUpdatePlans(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching managed software update plans: %v", err)
 	}

--- a/examples/managed_software_updates/GetManagedSoftwareUpdatePlans/GetManagedSoftwareUpdatePlans.go
+++ b/examples/managed_software_updates/GetManagedSoftwareUpdatePlans/GetManagedSoftwareUpdatePlans.go
@@ -26,6 +26,7 @@ func main() {
 	}
 
 	// Pretty print the managed software update plans in json
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	updatePlansJSON, err := json.MarshalIndent(updatePlans, "", "    ") // Indent with 4 spaces
 	if err != nil {
 		log.Fatalf("Error marshaling managed software update plans data: %v", err)

--- a/examples/patch_policies/GetPatchPolicies/GetPatchPolicies.go
+++ b/examples/patch_policies/GetPatchPolicies/GetPatchPolicies.go
@@ -20,7 +20,7 @@ func main() {
 	}
 
 	// Call GetPatchPolicies function to fetch policies
-	// You can provide sort parameters like "status:asc,updated:desc" or leave empty "" for default sorting
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	policies, err := client.GetPatchPolicies(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching patch policies: %v", err)

--- a/examples/patch_policies/GetPatchPolicies/GetPatchPolicies.go
+++ b/examples/patch_policies/GetPatchPolicies/GetPatchPolicies.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 
 	// Call GetPatchPolicies function to fetch policies
 	// You can provide sort parameters like "status:asc,updated:desc" or leave empty "" for default sorting
-	policies, err := client.GetPatchPolicies("")
+	policies, err := client.GetPatchPolicies(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching patch policies: %v", err)
 	}

--- a/examples/patch_software_title_configurations/GetPatchSoftwareTitleDefinitions/GetPatchSoftwareTitleDefinitions.go
+++ b/examples/patch_software_title_configurations/GetPatchSoftwareTitleDefinitions/GetPatchSoftwareTitleDefinitions.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Example software title ID and sort parameters
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	titleID := "14" // Example ID from previous logs
 	params := url.Values{}
 	params.Add("sort", "absoluteOrderId:asc")

--- a/examples/patch_software_title_configurations/GetPatchSoftwareTitleDefinitions/GetPatchSoftwareTitleDefinitions.go
+++ b/examples/patch_software_title_configurations/GetPatchSoftwareTitleDefinitions/GetPatchSoftwareTitleDefinitions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,11 +20,12 @@ func main() {
 	}
 
 	// Example software title ID and sort parameters
-	titleID := "14"                     // Example ID from previous logs
-	sortFilter := "absoluteOrderId:asc" // Example sort filter
+	titleID := "14" // Example ID from previous logs
+	params := url.Values{}
+	params.Add("sort", "absoluteOrderId:asc")
 
 	// Get the patch software title definitions
-	definitions, err := client.GetPatchSoftwareTitleDefinitions(titleID, sortFilter)
+	definitions, err := client.GetPatchSoftwareTitleDefinitions(titleID, params)
 	if err != nil {
 		log.Fatalf("Error getting patch software title definitions: %v", err)
 	}

--- a/examples/scripts/DeleteAllScripts/DeleteAllScripts.go
+++ b/examples/scripts/DeleteAllScripts/DeleteAllScripts.go
@@ -19,6 +19,7 @@ func main() {
 	}
 
 	// Fetch all scripts
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)

--- a/examples/scripts/DeleteAllScripts/DeleteAllScripts.go
+++ b/examples/scripts/DeleteAllScripts/DeleteAllScripts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -18,7 +19,7 @@ func main() {
 	}
 
 	// Fetch all scripts
-	scripts, err := client.GetScripts("")
+	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)
 	}

--- a/examples/scripts/GetScripts/GetScripts.go
+++ b/examples/scripts/GetScripts/GetScripts.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Call GetScripts function
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)

--- a/examples/scripts/GetScripts/GetScripts.go
+++ b/examples/scripts/GetScripts/GetScripts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,7 +20,7 @@ func main() {
 	}
 
 	// Call GetScripts function
-	scripts, err := client.GetScripts("")
+	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)
 	}

--- a/examples/self_service_branding_macos/GetSelfServiceBrandingMacOS/GetSelfServiceBrandingMacOS.go
+++ b/examples/self_service_branding_macos/GetSelfServiceBrandingMacOS/GetSelfServiceBrandingMacOS.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
@@ -20,10 +21,11 @@ func main() {
 	}
 
 	// Sort filter
-	sortFilter := "sort=id:desc"
+	params := url.Values{}
+	params.Add("sort", "id:desc")
 
 	// Call the GetSelfServiceBrandingMacOS function and handle any errors
-	branding, err := client.GetSelfServiceBrandingMacOS(sortFilter)
+	branding, err := client.GetSelfServiceBrandingMacOS(params)
 	if err != nil {
 		// If there's an error, log it to stderr and exit with a non-zero status code
 		fmt.Fprintf(os.Stderr, "Error fetching self-service branding for macOS: %v\n", err)

--- a/examples/self_service_branding_macos/GetSelfServiceBrandingMacOS/GetSelfServiceBrandingMacOS.go
+++ b/examples/self_service_branding_macos/GetSelfServiceBrandingMacOS/GetSelfServiceBrandingMacOS.go
@@ -21,6 +21,7 @@ func main() {
 	}
 
 	// Sort filter
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 	params.Add("sort", "id:desc")
 

--- a/examples/smart_computer_groups/GetSmartComputerGroupsV2/GetSmartComputerGroupsV2.go
+++ b/examples/smart_computer_groups/GetSmartComputerGroupsV2/GetSmartComputerGroupsV2.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -19,10 +20,12 @@ func main() {
 	}
 
 	// Set sorting filter (optional)
-	sortFilter := "name:asc"
+
+	params := url.Values{}
+	params.Add("sort", "name:asc")
 
 	// Call function
-	groups, err := client.GetSmartComputerGroupsV2(sortFilter)
+	groups, err := client.GetSmartComputerGroupsV2(params)
 	if err != nil {
 		log.Fatalf("Error fetching smart computer groups v2: %v", err)
 	}

--- a/examples/smart_computer_groups/GetSmartComputerGroupsV2/GetSmartComputerGroupsV2.go
+++ b/examples/smart_computer_groups/GetSmartComputerGroupsV2/GetSmartComputerGroupsV2.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Set sorting filter (optional)
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 
 	params := url.Values{}
 	params.Add("sort", "name:asc")

--- a/examples/volume_purchase_locations/GetVolumePurchaseLocations/GetVolumePurchaseLocations.go
+++ b/examples/volume_purchase_locations/GetVolumePurchaseLocations/GetVolumePurchaseLocations.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -20,7 +21,7 @@ func main() {
 
 	// Example of calling GetVolumePurchaseLocations
 	fmt.Println("Fetching all volume purchasing locations...")
-	vplList, err := client.GetVolumePurchaseLocations("") // Pass nil or empty for no sort/filter
+	vplList, err := client.GetVolumePurchaseLocations(url.Values{}) // Pass nil or empty for no sort/filter
 	if err != nil {
 		fmt.Printf("Error fetching volume purchasing locations: %v\n", err)
 		return

--- a/examples/volume_purchase_locations/GetVolumePurchaseLocations/GetVolumePurchaseLocations.go
+++ b/examples/volume_purchase_locations/GetVolumePurchaseLocations/GetVolumePurchaseLocations.go
@@ -20,6 +20,7 @@ func main() {
 	}
 
 	// Example of calling GetVolumePurchaseLocations
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	fmt.Println("Fetching all volume purchasing locations...")
 	vplList, err := client.GetVolumePurchaseLocations(url.Values{}) // Pass nil or empty for no sort/filter
 	if err != nil {

--- a/examples/volume_purchasing_subscriptions/GetVolumePurchasingSubscriptions/GetVolumePurchasingSubscriptions.go
+++ b/examples/volume_purchasing_subscriptions/GetVolumePurchasingSubscriptions/GetVolumePurchasingSubscriptions.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -18,7 +19,7 @@ func main() {
 	}
 
 	// Call the function with desired parameters
-	subscriptions, err := client.GetVolumePurchasingSubscriptions("")
+	subscriptions, err := client.GetVolumePurchasingSubscriptions(url.Values{})
 	if err != nil {
 		fmt.Printf("Error fetching volume purchasing subscriptions: %s\n", err)
 		return

--- a/examples/volume_purchasing_subscriptions/GetVolumePurchasingSubscriptions/GetVolumePurchasingSubscriptions.go
+++ b/examples/volume_purchasing_subscriptions/GetVolumePurchasingSubscriptions/GetVolumePurchasingSubscriptions.go
@@ -19,6 +19,7 @@ func main() {
 	}
 
 	// Call the function with desired parameters
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	subscriptions, err := client.GetVolumePurchasingSubscriptions(url.Values{})
 	if err != nil {
 		fmt.Printf("Error fetching volume purchasing subscriptions: %s\n", err)

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -28,6 +28,7 @@ func GenerateRandomRecoveryLockPassword() string {
 }
 
 // GetManagementIDByDeviceName retrieves the management ID for a device by its name.
+// For more information on how to add parameters to this request, see docs/url_queries.md
 func GetManagementIDByDeviceName(client *jamfpro.Client, deviceName string) (string, error) {
 	inventories, err := client.GetComputersInventory(url.Values{})
 	if err != nil {

--- a/modules/helpers.go
+++ b/modules/helpers.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"fmt"
 	"math/rand"
+	"net/url"
 	"time"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
@@ -28,7 +29,7 @@ func GenerateRandomRecoveryLockPassword() string {
 
 // GetManagementIDByDeviceName retrieves the management ID for a device by its name.
 func GetManagementIDByDeviceName(client *jamfpro.Client, deviceName string) (string, error) {
-	inventories, err := client.GetComputersInventory("")
+	inventories, err := client.GetComputersInventory(url.Values{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get computer inventory: %w", err)
 	}

--- a/recipes/computer_extension_attributes/DeleteAllComputerExtensionAttributes/DeleteAllComputerExtensionAttributes.go
+++ b/recipes/computer_extension_attributes/DeleteAllComputerExtensionAttributes/DeleteAllComputerExtensionAttributes.go
@@ -19,6 +19,7 @@ func main() {
 	}
 
 	// Fetch all computer extension attributes
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	extAtts, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer extension attributes: %v", err)

--- a/recipes/computer_extension_attributes/DeleteAllComputerExtensionAttributes/DeleteAllComputerExtensionAttributes.go
+++ b/recipes/computer_extension_attributes/DeleteAllComputerExtensionAttributes/DeleteAllComputerExtensionAttributes.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -18,7 +19,7 @@ func main() {
 	}
 
 	// Fetch all computer extension attributes
-	extAtts, err := client.GetComputerExtensionAttributes("")
+	extAtts, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer extension attributes: %v", err)
 	}

--- a/recipes/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
+++ b/recipes/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
@@ -42,6 +42,7 @@ func main() {
 	}
 
 	// Get a list of all computer extension attributes
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	attributesList, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to fetch Computer Extension Attributes: %v", err)

--- a/recipes/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
+++ b/recipes/computer_extension_attributes/ExportComputerExtensionAttributes/ExportComputerExtensionAttributes.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -41,7 +42,7 @@ func main() {
 	}
 
 	// Get a list of all computer extension attributes
-	attributesList, err := client.GetComputerExtensionAttributes("")
+	attributesList, err := client.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to fetch Computer Extension Attributes: %v", err)
 	}

--- a/recipes/computer_inventory/FindAllUsersWithMoreThanOneMacAndExportToCSV/FindAllUsersWithMoreThanOneMacAndExportToCSV.go
+++ b/recipes/computer_inventory/FindAllUsersWithMoreThanOneMacAndExportToCSV/FindAllUsersWithMoreThanOneMacAndExportToCSV.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 
@@ -27,8 +28,8 @@ func main() {
 	}
 
 	// Get computer inventory with all data
-	sortFilter := "id:asc"
-	inventoryList, err := client.GetComputersInventory(sortFilter)
+	params := url.Values{}
+	inventoryList, err := client.GetComputersInventory(params)
 	if err != nil {
 		log.Fatalf("Failed to get computer inventory data: %v", err)
 	}

--- a/recipes/computer_inventory/FindAllUsersWithMoreThanOneMacAndExportToCSV/FindAllUsersWithMoreThanOneMacAndExportToCSV.go
+++ b/recipes/computer_inventory/FindAllUsersWithMoreThanOneMacAndExportToCSV/FindAllUsersWithMoreThanOneMacAndExportToCSV.go
@@ -28,6 +28,7 @@ func main() {
 	}
 
 	// Get computer inventory with all data
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	params := url.Values{}
 	inventoryList, err := client.GetComputersInventory(params)
 	if err != nil {

--- a/recipes/mdm/ClearFailedMDMCommands/ClearFailedMDMCommands.go
+++ b/recipes/mdm/ClearFailedMDMCommands/ClearFailedMDMCommands.go
@@ -42,6 +42,7 @@ func main() {
 	fmt.Printf("Hardware UUID: %s\n", macUUID)
 
 	// Get computers inventory to find computer by UUID
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	inventory, err := client.GetComputersInventory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer inventory: %v", err)

--- a/recipes/mdm/ClearFailedMDMCommands/ClearFailedMDMCommands.go
+++ b/recipes/mdm/ClearFailedMDMCommands/ClearFailedMDMCommands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/modules"
@@ -41,7 +42,7 @@ func main() {
 	fmt.Printf("Hardware UUID: %s\n", macUUID)
 
 	// Get computers inventory to find computer by UUID
-	inventory, err := client.GetComputersInventory("")
+	inventory, err := client.GetComputersInventory(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching computer inventory: %v", err)
 	}

--- a/recipes/patch_management/UploadPackageAndAssignToPatchPolicy/UploadPackageAndAssignToPatchPolicy.go
+++ b/recipes/patch_management/UploadPackageAndAssignToPatchPolicy/UploadPackageAndAssignToPatchPolicy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
+	"net/url"
 	"path/filepath"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
@@ -126,7 +127,7 @@ func main() {
 	fmt.Printf("Patch Software Title Configuration Response: %s\n", string(responseJson))
 
 	// Step 4: Get the Patch Software Title Definitions to retrieve missing values
-	softwareTitleDefinitions, err := client.GetPatchSoftwareTitleDefinitions(softwareTitle.ID, "")
+	softwareTitleDefinitions, err := client.GetPatchSoftwareTitleDefinitions(softwareTitle.ID, url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to get patch software title definitions: %v", err)
 	}

--- a/recipes/patch_management/UploadPackageAndAssignToPatchPolicy/UploadPackageAndAssignToPatchPolicy.go
+++ b/recipes/patch_management/UploadPackageAndAssignToPatchPolicy/UploadPackageAndAssignToPatchPolicy.go
@@ -127,6 +127,7 @@ func main() {
 	fmt.Printf("Patch Software Title Configuration Response: %s\n", string(responseJson))
 
 	// Step 4: Get the Patch Software Title Definitions to retrieve missing values
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	softwareTitleDefinitions, err := client.GetPatchSoftwareTitleDefinitions(softwareTitle.ID, url.Values{})
 	if err != nil {
 		log.Fatalf("Failed to get patch software title definitions: %v", err)

--- a/recipes/privileges/Export_All_Assigned_Privileges_By_Api_Integration/Export_All_Assigned_Privileges_By_Api_Integration.go
+++ b/recipes/privileges/Export_All_Assigned_Privileges_By_Api_Integration/Export_All_Assigned_Privileges_By_Api_Integration.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +22,7 @@ func main() {
 	}
 
 	// Fetch all API integrations
-	integrations, err := client.GetApiIntegrations("")
+	integrations, err := client.GetApiIntegrations(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API integrations: %v", err)
 	}
@@ -53,7 +54,7 @@ func main() {
 	// Process each integration
 	for _, integration := range integrations.Results {
 		// Fetch API roles for this integration
-		roles, err := client.GetJamfAPIRoles("")
+		roles, err := client.GetJamfAPIRoles(url.Values{})
 		if err != nil {
 			log.Printf("Error fetching API roles for integration %d: %v", integration.ID, err)
 			continue

--- a/recipes/privileges/Export_All_Assigned_Privileges_By_Api_Integration/Export_All_Assigned_Privileges_By_Api_Integration.go
+++ b/recipes/privileges/Export_All_Assigned_Privileges_By_Api_Integration/Export_All_Assigned_Privileges_By_Api_Integration.go
@@ -22,6 +22,7 @@ func main() {
 	}
 
 	// Fetch all API integrations
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	integrations, err := client.GetApiIntegrations(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching API integrations: %v", err)
@@ -54,6 +55,7 @@ func main() {
 	// Process each integration
 	for _, integration := range integrations.Results {
 		// Fetch API roles for this integration
+		// For more information on how to add parameters to this request, see docs/url_queries.md
 		roles, err := client.GetJamfAPIRoles(url.Values{})
 		if err != nil {
 			log.Printf("Error fetching API roles for integration %d: %v", integration.ID, err)

--- a/recipes/scripts/DeleteAllScripts/DeleteAllScripts.go
+++ b/recipes/scripts/DeleteAllScripts/DeleteAllScripts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 )
@@ -17,7 +18,7 @@ func main() {
 	}
 
 	// Fetch all scripts
-	scripts, err := client.GetScripts("")
+	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)
 	}

--- a/recipes/scripts/DeleteAllScripts/DeleteAllScripts.go
+++ b/recipes/scripts/DeleteAllScripts/DeleteAllScripts.go
@@ -18,6 +18,7 @@ func main() {
 	}
 
 	// Fetch all scripts
+	// For more information on how to add parameters to this request, see docs/url_queries.md
 	scripts, err := client.GetScripts(url.Values{})
 	if err != nil {
 		log.Fatalf("Error fetching scripts: %v", err)

--- a/sdk/jamfpro/jamfproapi_api_integrations.go
+++ b/sdk/jamfpro/jamfproapi_api_integrations.go
@@ -46,8 +46,7 @@ type ResourceClientCredentials struct {
 
 // GetApiIntegrations fetches all API integrations
 func (c *Client) GetApiIntegrations(params url.Values) (*ResponseApiIntegrationsList, error) {
-	endpoint := uriApiIntegrations
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
+	resp, err := c.DoPaginatedGet(uriApiIntegrations, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api integrations", err)
 	}

--- a/sdk/jamfpro/jamfproapi_api_integrations.go
+++ b/sdk/jamfpro/jamfproapi_api_integrations.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/mitchellh/mapstructure"
@@ -44,9 +45,9 @@ type ResourceClientCredentials struct {
 // CRUD
 
 // GetApiIntegrations fetches all API integrations
-func (c *Client) GetApiIntegrations(sort_filter string) (*ResponseApiIntegrationsList, error) {
+func (c *Client) GetApiIntegrations(params url.Values) (*ResponseApiIntegrationsList, error) {
 	endpoint := uriApiIntegrations
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api integrations", err)
 	}
@@ -84,7 +85,7 @@ func (c *Client) GetApiIntegrationByID(id string) (*ResourceApiIntegration, erro
 
 // GetApiIntegrationNameByID fetches an API integration by its display name and then retrieves its details using its ID
 func (c *Client) GetApiIntegrationByName(name string) (*ResourceApiIntegration, error) {
-	integrations, err := c.GetApiIntegrations("")
+	integrations, err := c.GetApiIntegrations(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api integration", err)
 	}

--- a/sdk/jamfpro/jamfproapi_api_integrations.go
+++ b/sdk/jamfpro/jamfproapi_api_integrations.go
@@ -84,7 +84,7 @@ func (c *Client) GetApiIntegrationByID(id string) (*ResourceApiIntegration, erro
 
 // GetApiIntegrationNameByID fetches an API integration by its display name and then retrieves its details using its ID
 func (c *Client) GetApiIntegrationByName(name string) (*ResourceApiIntegration, error) {
-	integrations, err := c.GetApiIntegrations(url.Values{})
+	integrations, err := c.GetApiIntegrations(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api integration", err)
 	}

--- a/sdk/jamfpro/jamfproapi_api_roles.go
+++ b/sdk/jamfpro/jamfproapi_api_roles.go
@@ -74,7 +74,7 @@ func (c *Client) GetJamfApiRoleByID(id string) (*ResourceAPIRole, error) {
 
 // GetJamfApiRolesNameById fetches a Jamf API role by its display name and then retrieves its details using its ID.
 func (c *Client) GetJamfApiRoleByName(name string) (*ResourceAPIRole, error) {
-	roles, err := c.GetJamfAPIRoles(url.Values{})
+	roles, err := c.GetJamfAPIRoles(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api role", err)
 	}

--- a/sdk/jamfpro/jamfproapi_api_roles.go
+++ b/sdk/jamfpro/jamfproapi_api_roles.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -33,10 +34,10 @@ type ResourceAPIRole struct {
 // CRUD
 
 // GetJamfAPIRoles fetches a list of Jamf API roles
-func (c *Client) GetJamfAPIRoles(sort_filter string) (*ResponseApiRolesList, error) {
+func (c *Client) GetJamfAPIRoles(params url.Values) (*ResponseApiRolesList, error) {
 	endpoint := uriApiRoles
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api roles", err)
 	}
@@ -74,7 +75,7 @@ func (c *Client) GetJamfApiRoleByID(id string) (*ResourceAPIRole, error) {
 
 // GetJamfApiRolesNameById fetches a Jamf API role by its display name and then retrieves its details using its ID.
 func (c *Client) GetJamfApiRoleByName(name string) (*ResourceAPIRole, error) {
-	roles, err := c.GetJamfAPIRoles("")
+	roles, err := c.GetJamfAPIRoles(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api role", err)
 	}

--- a/sdk/jamfpro/jamfproapi_api_roles.go
+++ b/sdk/jamfpro/jamfproapi_api_roles.go
@@ -35,9 +35,8 @@ type ResourceAPIRole struct {
 
 // GetJamfAPIRoles fetches a list of Jamf API roles
 func (c *Client) GetJamfAPIRoles(params url.Values) (*ResponseApiRolesList, error) {
-	endpoint := uriApiRoles
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
+	resp, err := c.DoPaginatedGet(uriApiRoles, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "api roles", err)
 	}

--- a/sdk/jamfpro/jamfproapi_app_installers.go
+++ b/sdk/jamfpro/jamfproapi_app_installers.go
@@ -239,7 +239,7 @@ func (c *Client) GetJamfAppCatalogAppInstallerByName(name string) (*ResourceJamf
 
 // GetJamfAppCatalogAppInstallerByTitleName retrieves title by name & returns ResourceJamfAppCatalogAppInstaller
 func (c *Client) GetJamfAppCatalogAppInstallerByTitleName(name string) (*ResourceJamfAppCatalogAppInstaller, error) {
-	titles, err := c.GetJamfAppCatalogAppInstallerTitles(url.Values{})
+	titles, err := c.GetJamfAppCatalogAppInstallerTitles(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf App Catalog Titles", err)
 	}

--- a/sdk/jamfpro/jamfproapi_app_installers.go
+++ b/sdk/jamfpro/jamfproapi_app_installers.go
@@ -156,12 +156,7 @@ func (c *Client) AcceptJamfAppCatalogAppInstallerTermsAndConditions() (*Response
 
 // Gets full list of Get Jamf App Catalog App Installer Titles & handles pagination
 func (c *Client) GetJamfAppCatalogAppInstallerTitles(params url.Values) (*ResponseJamfAppCatalogTitleList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriJamfAppCatalogAppInstaller+"/titles",
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriJamfAppCatalogAppInstaller+"/titles", params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf App Catalog Titles", err)

--- a/sdk/jamfpro/jamfproapi_app_installers.go
+++ b/sdk/jamfpro/jamfproapi_app_installers.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -154,12 +155,12 @@ func (c *Client) AcceptJamfAppCatalogAppInstallerTermsAndConditions() (*Response
 }
 
 // Gets full list of Get Jamf App Catalog App Installer Titles & handles pagination
-func (c *Client) GetJamfAppCatalogAppInstallerTitles(sort_filter string) (*ResponseJamfAppCatalogTitleList, error) {
+func (c *Client) GetJamfAppCatalogAppInstallerTitles(params url.Values) (*ResponseJamfAppCatalogTitleList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriJamfAppCatalogAppInstaller+"/titles",
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -243,7 +244,7 @@ func (c *Client) GetJamfAppCatalogAppInstallerByName(name string) (*ResourceJamf
 
 // GetJamfAppCatalogAppInstallerByTitleName retrieves title by name & returns ResourceJamfAppCatalogAppInstaller
 func (c *Client) GetJamfAppCatalogAppInstallerByTitleName(name string) (*ResourceJamfAppCatalogAppInstaller, error) {
-	titles, err := c.GetJamfAppCatalogAppInstallerTitles("")
+	titles, err := c.GetJamfAppCatalogAppInstallerTitles(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf App Catalog Titles", err)
 	}

--- a/sdk/jamfpro/jamfproapi_bookmarks.go
+++ b/sdk/jamfpro/jamfproapi_bookmarks.go
@@ -88,7 +88,7 @@ func (c *Client) GetBookmarkByID(id string) (*ResourceBookmark, error) {
 
 // GetBookmarkByName retrieves a single bookmark information by its name
 func (c *Client) GetBookmarkByName(name string) (*ResourceBookmark, error) {
-	bookmarks, err := c.GetBookmarks(url.Values{})
+	bookmarks, err := c.GetBookmarks(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "bookmark", err)
 	}

--- a/sdk/jamfpro/jamfproapi_bookmarks.go
+++ b/sdk/jamfpro/jamfproapi_bookmarks.go
@@ -48,12 +48,7 @@ type ResourceBookmark struct {
 
 // GetBookmarks retrieves all bookmark information with optional sorting
 func (c *Client) GetBookmarks(params url.Values) (*ResponseBookmarksList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriBookmarks,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriBookmarks, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "bookmarks", err)

--- a/sdk/jamfpro/jamfproapi_bookmarks.go
+++ b/sdk/jamfpro/jamfproapi_bookmarks.go
@@ -6,6 +6,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -46,12 +47,12 @@ type ResourceBookmark struct {
 // CRUD
 
 // GetBookmarks retrieves all bookmark information with optional sorting
-func (c *Client) GetBookmarks(sort_filter string) (*ResponseBookmarksList, error) {
+func (c *Client) GetBookmarks(params url.Values) (*ResponseBookmarksList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriBookmarks,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -92,7 +93,7 @@ func (c *Client) GetBookmarkByID(id string) (*ResourceBookmark, error) {
 
 // GetBookmarkByName retrieves a single bookmark information by its name
 func (c *Client) GetBookmarkByName(name string) (*ResourceBookmark, error) {
-	bookmarks, err := c.GetBookmarks("")
+	bookmarks, err := c.GetBookmarks(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "bookmark", err)
 	}

--- a/sdk/jamfpro/jamfproapi_buildings.go
+++ b/sdk/jamfpro/jamfproapi_buildings.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -61,12 +62,12 @@ type ResourceBuildingResourceHistory struct {
 // CRUD
 
 // GetBuildings retrieves all building information with optional sorting.
-func (c *Client) GetBuildings(sort_filter string) (*ResponseBuildingsList, error) {
+func (c *Client) GetBuildings(params url.Values) (*ResponseBuildingsList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriBuildings,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -107,7 +108,7 @@ func (c *Client) GetBuildingByID(id string) (*ResourceBuilding, error) {
 
 // GetBuildingByNameByID retrieves a single building information by its name using GetBuildingByID.
 func (c *Client) GetBuildingByName(name string) (*ResourceBuilding, error) {
-	buildings, err := c.GetBuildings("")
+	buildings, err := c.GetBuildings(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "building", err)
 	}
@@ -229,10 +230,10 @@ func (c *Client) DeleteMultipleBuildingsByID(ids []string) error {
 }
 
 // GetBuildingResourceHistoryByID retrieves the resource history of a specific building by its ID.
-func (c *Client) GetBuildingResourceHistoryByID(id, sort_filter string) (*ResponseBuildingResourceHistoryList, error) {
+func (c *Client) GetBuildingResourceHistoryByID(id string, params url.Values) (*ResponseBuildingResourceHistoryList, error) {
 	endpoint := fmt.Sprintf("%s/%s/history", uriBuildings, id)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "building histories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_buildings.go
+++ b/sdk/jamfpro/jamfproapi_buildings.go
@@ -63,12 +63,7 @@ type ResourceBuildingResourceHistory struct {
 
 // GetBuildings retrieves all building information with optional sorting.
 func (c *Client) GetBuildings(params url.Values) (*ResponseBuildingsList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriBuildings,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriBuildings, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "buildings", err)
@@ -233,7 +228,7 @@ func (c *Client) DeleteMultipleBuildingsByID(ids []string) error {
 func (c *Client) GetBuildingResourceHistoryByID(id string, params url.Values) (*ResponseBuildingResourceHistoryList, error) {
 	endpoint := fmt.Sprintf("%s/%s/history", uriBuildings, id)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "building histories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_buildings.go
+++ b/sdk/jamfpro/jamfproapi_buildings.go
@@ -103,7 +103,7 @@ func (c *Client) GetBuildingByID(id string) (*ResourceBuilding, error) {
 
 // GetBuildingByNameByID retrieves a single building information by its name using GetBuildingByID.
 func (c *Client) GetBuildingByName(name string) (*ResourceBuilding, error) {
-	buildings, err := c.GetBuildings(url.Values{})
+	buildings, err := c.GetBuildings(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "building", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -43,8 +44,8 @@ type ResponseCategoryCreateAndUpdate struct {
 // Parameters:
 // - sort: A string specifying the sorting order of the returned categories.
 // - filter: A string to filter the categories based on certain criteria.
-func (c *Client) GetCategories(sort_filter string) (*ResponseCategoriesList, error) {
-	resp, err := c.DoPaginatedGet(uriCategories, standardPageSize, startingPageNumber, sort_filter)
+func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, error) {
+	resp, err := c.DoPaginatedGet(uriCategories, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}
@@ -83,7 +84,7 @@ func (c *Client) GetCategoryByID(id string) (*ResourceCategory, error) {
 
 // GetCategoryNameByID retrieves a category by its name and then retrieves its details using its ID
 func (c *Client) GetCategoryByName(name string) (*ResourceCategory, error) {
-	categories, err := c.GetCategories("")
+	categories, err := c.GetCategories(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -45,7 +45,8 @@ type ResponseCategoryCreateAndUpdate struct {
 // - sort: A string specifying the sorting order of the returned categories.
 // - filter: A string to filter the categories based on certain criteria.
 func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, error) {
-	resp, err := c.DoPaginatedGet(uriCategories, 1, 0, params)
+	resp, err := c.DoPaginatedGet(uriCategories, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -54,6 +54,8 @@ func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, erro
 	out.TotalCount = resp.Size
 
 	for _, value := range resp.Results {
+		fmt.Println("LOOP")
+		fmt.Println(value)
 		var newObj ResourceCategory
 		err := mapstructure.Decode(value, &newObj)
 		if err != nil {

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -51,14 +51,10 @@ func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, erro
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}
 
-	fmt.Println(resp.Results)
-
 	var out ResponseCategoriesList
 	out.TotalCount = resp.Size
 
 	for _, value := range resp.Results {
-		fmt.Println("LOOP")
-		fmt.Println(value)
 		var newObj ResourceCategory
 		err := mapstructure.Decode(value, &newObj)
 		if err != nil {

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -45,7 +45,7 @@ type ResponseCategoryCreateAndUpdate struct {
 // - sort: A string specifying the sorting order of the returned categories.
 // - filter: A string to filter the categories based on certain criteria.
 func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, error) {
-	resp, err := c.DoPaginatedGet(uriCategories, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(uriCategories, 100, 1, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -45,7 +45,7 @@ type ResponseCategoryCreateAndUpdate struct {
 // - sort: A string specifying the sorting order of the returned categories.
 // - filter: A string to filter the categories based on certain criteria.
 func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, error) {
-	resp, err := c.DoPaginatedGet(uriCategories, 100, 1, params)
+	resp, err := c.DoPaginatedGet(uriCategories, 1, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -85,7 +85,7 @@ func (c *Client) GetCategoryByID(id string) (*ResourceCategory, error) {
 
 // GetCategoryNameByID retrieves a category by its name and then retrieves its details using its ID
 func (c *Client) GetCategoryByName(name string) (*ResourceCategory, error) {
-	categories, err := c.GetCategories(url.Values{})
+	categories, err := c.GetCategories(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_categories.go
+++ b/sdk/jamfpro/jamfproapi_categories.go
@@ -50,6 +50,8 @@ func (c *Client) GetCategories(params url.Values) (*ResponseCategoriesList, erro
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "categories", err)
 	}
 
+	fmt.Println(resp.Results)
+
 	var out ResponseCategoriesList
 	out.TotalCount = resp.Size
 

--- a/sdk/jamfpro/jamfproapi_cloud_idp.go
+++ b/sdk/jamfpro/jamfproapi_cloud_idp.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -33,9 +34,9 @@ type ResourceCloudIdentityProvider struct {
 }
 
 // GetCloudIdentityProviders retrieves all cloud identity provider configurations
-func (c *Client) GetCloudIdentityProviders(sort_filter string) (*ResponseCloudIdentityProvidersList, error) {
+func (c *Client) GetCloudIdentityProviders(params url.Values) (*ResponseCloudIdentityProvidersList, error) {
 	endpoint := uriCloudIdp
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "cloud identity providers", err)
 	}
@@ -80,7 +81,7 @@ func (c *Client) GetCloudIdentityProviderConfigurationByID(id string) (*Resource
 
 // GetCloudIdentityProviderConfigurationByName retrieves a cloud identity provider by its display name
 func (c *Client) GetCloudIdentityProviderConfigurationByName(name string) (*ResourceCloudIdentityProvider, error) {
-	providers, err := c.GetCloudIdentityProviders("")
+	providers, err := c.GetCloudIdentityProviders(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cloud identity providers: %v", err)
 	}

--- a/sdk/jamfpro/jamfproapi_cloud_idp.go
+++ b/sdk/jamfpro/jamfproapi_cloud_idp.go
@@ -35,8 +35,8 @@ type ResourceCloudIdentityProvider struct {
 
 // GetCloudIdentityProviders retrieves all cloud identity provider configurations
 func (c *Client) GetCloudIdentityProviders(params url.Values) (*ResponseCloudIdentityProvidersList, error) {
-	endpoint := uriCloudIdp
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
+
+	resp, err := c.DoPaginatedGet(uriCloudIdp, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "cloud identity providers", err)
 	}

--- a/sdk/jamfpro/jamfproapi_cloud_idp.go
+++ b/sdk/jamfpro/jamfproapi_cloud_idp.go
@@ -81,7 +81,7 @@ func (c *Client) GetCloudIdentityProviderConfigurationByID(id string) (*Resource
 
 // GetCloudIdentityProviderConfigurationByName retrieves a cloud identity provider by its display name
 func (c *Client) GetCloudIdentityProviderConfigurationByName(name string) (*ResourceCloudIdentityProvider, error) {
-	providers, err := c.GetCloudIdentityProviders(url.Values{})
+	providers, err := c.GetCloudIdentityProviders(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cloud identity providers: %v", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
+++ b/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
@@ -2,6 +2,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -36,12 +37,12 @@ type ResponseComputerExtensionAttributeCreated struct {
 }
 
 // GetComputerExtensionAttributes retrieves all computer extension attributes with pagination
-func (c *Client) GetComputerExtensionAttributes(sortFilter string) (*ResponseComputerExtensionAttributesList, error) {
+func (c *Client) GetComputerExtensionAttributes(params url.Values) (*ResponseComputerExtensionAttributesList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriComputerExtensionAttributes,
 		standardPageSize,
 		startingPageNumber,
-		sortFilter,
+		params,
 	)
 
 	if err != nil {
@@ -82,7 +83,7 @@ func (c *Client) GetComputerExtensionAttributeByID(id string) (*ResourceComputer
 
 // GetComputerExtensionAttributeByName retrieves a computer extension attribute by its name
 func (c *Client) GetComputerExtensionAttributeByName(name string) (*ResourceComputerExtensionAttribute, error) {
-	attributes, err := c.GetComputerExtensionAttributes("")
+	attributes, err := c.GetComputerExtensionAttributes(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer extension attributes", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
+++ b/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
@@ -38,12 +38,7 @@ type ResponseComputerExtensionAttributeCreated struct {
 
 // GetComputerExtensionAttributes retrieves all computer extension attributes with pagination
 func (c *Client) GetComputerExtensionAttributes(params url.Values) (*ResponseComputerExtensionAttributesList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriComputerExtensionAttributes,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriComputerExtensionAttributes, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer extension attributes", err)

--- a/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
+++ b/sdk/jamfpro/jamfproapi_computer_extension_attributes.go
@@ -78,7 +78,7 @@ func (c *Client) GetComputerExtensionAttributeByID(id string) (*ResourceComputer
 
 // GetComputerExtensionAttributeByName retrieves a computer extension attribute by its name
 func (c *Client) GetComputerExtensionAttributeByName(name string) (*ResourceComputerExtensionAttribute, error) {
-	attributes, err := c.GetComputerExtensionAttributes(url.Values{})
+	attributes, err := c.GetComputerExtensionAttributes(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer extension attributes", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -551,12 +551,8 @@ type RequestEraseDeviceComputer struct {
 
 // GetComputersInventory retrieves all computer inventory information with optional sorting and section filters.
 func (c *Client) GetComputersInventory(params url.Values) (*ResponseComputerInventoryList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriComputersInventory,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriComputersInventory, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computers-inventories", err)
 	}
@@ -646,12 +642,8 @@ func (c *Client) DeleteComputerInventoryByID(id string) error {
 // GetComputersFileVaultInventory retrieves all computer inventory filevault information.
 func (c *Client) GetComputersFileVaultInventory(params url.Values) (*FileVaultInventoryList, error) {
 	endpoint := fmt.Sprintf("%s/filevault", uriComputersInventory)
-	resp, err := c.DoPaginatedGet(
-		endpoint,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(endpoint, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "filevault inventories", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -592,7 +592,7 @@ func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory
 
 // GetComputerInventoryByName retrieves a specific computer's inventory information by its name.
 func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInventory, error) {
-	inventories, err := c.GetComputersInventory(url.Values{})
+	inventories, err := c.GetComputersInventory(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer inventory", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -13,6 +13,7 @@ package jamfpro
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -549,12 +550,12 @@ type RequestEraseDeviceComputer struct {
 // CRUD
 
 // GetComputersInventory retrieves all computer inventory information with optional sorting and section filters.
-func (c *Client) GetComputersInventory(sort_filter string) (*ResponseComputerInventoryList, error) {
+func (c *Client) GetComputersInventory(params url.Values) (*ResponseComputerInventoryList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriComputersInventory,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computers-inventories", err)
@@ -595,7 +596,7 @@ func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory
 
 // GetComputerInventoryByName retrieves a specific computer's inventory information by its name.
 func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInventory, error) {
-	inventories, err := c.GetComputersInventory("")
+	inventories, err := c.GetComputersInventory(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer inventory", err)
 	}
@@ -643,13 +644,13 @@ func (c *Client) DeleteComputerInventoryByID(id string) error {
 }
 
 // GetComputersFileVaultInventory retrieves all computer inventory filevault information.
-func (c *Client) GetComputersFileVaultInventory(sort_filter string) (*FileVaultInventoryList, error) {
+func (c *Client) GetComputersFileVaultInventory(params url.Values) (*FileVaultInventoryList, error) {
 	endpoint := fmt.Sprintf("%s/filevault", uriComputersInventory)
 	resp, err := c.DoPaginatedGet(
 		endpoint,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "filevault inventories", err)

--- a/sdk/jamfpro/jamfproapi_computer_prestages.go
+++ b/sdk/jamfpro/jamfproapi_computer_prestages.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -190,12 +191,12 @@ type OnboardingItem struct {
 // CRUD
 
 // GetComputerPrestagesV3 retrieves all computer prestage information with optional sorting.
-func (c *Client) GetComputerPrestages(sort_filter string) (*ResponseComputerPrestagesList, error) {
+func (c *Client) GetComputerPrestages(params url.Values) (*ResponseComputerPrestagesList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriComputerPrestagesV3,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -235,7 +236,7 @@ func (c *Client) GetComputerPrestageByID(id string) (*ResourceComputerPrestage, 
 
 // GetComputerPrestageByName retrieves a specific computer prestage by its name.
 func (c *Client) GetComputerPrestageByName(name string) (*ResourceComputerPrestage, error) {
-	prestages, err := c.GetComputerPrestages("")
+	prestages, err := c.GetComputerPrestages(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer prestages", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_prestages.go
+++ b/sdk/jamfpro/jamfproapi_computer_prestages.go
@@ -231,7 +231,7 @@ func (c *Client) GetComputerPrestageByID(id string) (*ResourceComputerPrestage, 
 
 // GetComputerPrestageByName retrieves a specific computer prestage by its name.
 func (c *Client) GetComputerPrestageByName(name string) (*ResourceComputerPrestage, error) {
-	prestages, err := c.GetComputerPrestages(url.Values{})
+	prestages, err := c.GetComputerPrestages(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer prestages", err)
 	}

--- a/sdk/jamfpro/jamfproapi_computer_prestages.go
+++ b/sdk/jamfpro/jamfproapi_computer_prestages.go
@@ -192,12 +192,7 @@ type OnboardingItem struct {
 
 // GetComputerPrestagesV3 retrieves all computer prestage information with optional sorting.
 func (c *Client) GetComputerPrestages(params url.Values) (*ResponseComputerPrestagesList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriComputerPrestagesV3,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriComputerPrestagesV3, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer prestages", err)

--- a/sdk/jamfpro/jamfproapi_departments.go
+++ b/sdk/jamfpro/jamfproapi_departments.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -33,13 +34,13 @@ type ResourceDepartment struct {
 }
 
 // GetDepartments retrieves a list of all departments in list
-func (c *Client) GetDepartments(sort_filter string) (*ResponseDepartmentsList, error) {
+func (c *Client) GetDepartments(params url.Values) (*ResponseDepartmentsList, error) {
 	endpoint := uriDepartments
 	resp, err := c.DoPaginatedGet(
 		endpoint,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "departments", err)
@@ -79,7 +80,7 @@ func (c *Client) GetDepartmentByID(id string) (*ResourceDepartment, error) {
 
 // GetDepartmentByName retrieves a department by Name.
 func (c *Client) GetDepartmentByName(name string) (*ResourceDepartment, error) {
-	depts, err := c.GetDepartments("")
+	depts, err := c.GetDepartments(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "departments", err)
 	}

--- a/sdk/jamfpro/jamfproapi_departments.go
+++ b/sdk/jamfpro/jamfproapi_departments.go
@@ -76,7 +76,7 @@ func (c *Client) GetDepartmentByID(id string) (*ResourceDepartment, error) {
 
 // GetDepartmentByName retrieves a department by Name.
 func (c *Client) GetDepartmentByName(name string) (*ResourceDepartment, error) {
-	depts, err := c.GetDepartments(url.Values{})
+	depts, err := c.GetDepartments(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "departments", err)
 	}

--- a/sdk/jamfpro/jamfproapi_departments.go
+++ b/sdk/jamfpro/jamfproapi_departments.go
@@ -36,12 +36,8 @@ type ResourceDepartment struct {
 // GetDepartments retrieves a list of all departments in list
 func (c *Client) GetDepartments(params url.Values) (*ResponseDepartmentsList, error) {
 	endpoint := uriDepartments
-	resp, err := c.DoPaginatedGet(
-		endpoint,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(endpoint, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "departments", err)
 	}

--- a/sdk/jamfpro/jamfproapi_device_enrollments.go
+++ b/sdk/jamfpro/jamfproapi_device_enrollments.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -85,12 +86,12 @@ type ResponseDeviceEnrollmentTokenUpload struct {
 // CRUD
 
 // GetDeviceEnrollments retrieves a paginated list of device enrollments.
-func (c *Client) GetDeviceEnrollments(sort_filter string) (*ResponseDeviceEnrollmentsList, error) {
+func (c *Client) GetDeviceEnrollments(params url.Values) (*ResponseDeviceEnrollmentsList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriDeviceEnrollments,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "device enrollments", err)
@@ -130,7 +131,7 @@ func (c *Client) GetDeviceEnrollmentByID(id string) (*ResourceDeviceEnrollment, 
 
 // GetDeviceEnrollmentByName retrieves a device enrollment by Name.
 func (c *Client) GetDeviceEnrollmentByName(name string) (*ResourceDeviceEnrollment, error) {
-	enrollments, err := c.GetDeviceEnrollments("")
+	enrollments, err := c.GetDeviceEnrollments(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "device enrollments", err)
 	}
@@ -145,7 +146,7 @@ func (c *Client) GetDeviceEnrollmentByName(name string) (*ResourceDeviceEnrollme
 }
 
 // GetDeviceEnrollmentHistory retrieves the history for a specific device enrollment
-func (c *Client) GetDeviceEnrollmentHistory(id string, sort_filter string) (*ResponseDeviceEnrollmentHistory, error) {
+func (c *Client) GetDeviceEnrollmentHistory(id string, params url.Values) (*ResponseDeviceEnrollmentHistory, error) {
 	endpoint := fmt.Sprintf("%s/%s/history", uriDeviceEnrollments, id)
 	var out ResponseDeviceEnrollmentHistory
 	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &out)

--- a/sdk/jamfpro/jamfproapi_device_enrollments.go
+++ b/sdk/jamfpro/jamfproapi_device_enrollments.go
@@ -87,12 +87,8 @@ type ResponseDeviceEnrollmentTokenUpload struct {
 
 // GetDeviceEnrollments retrieves a paginated list of device enrollments.
 func (c *Client) GetDeviceEnrollments(params url.Values) (*ResponseDeviceEnrollmentsList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriDeviceEnrollments,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriDeviceEnrollments, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "device enrollments", err)
 	}

--- a/sdk/jamfpro/jamfproapi_device_enrollments.go
+++ b/sdk/jamfpro/jamfproapi_device_enrollments.go
@@ -127,7 +127,7 @@ func (c *Client) GetDeviceEnrollmentByID(id string) (*ResourceDeviceEnrollment, 
 
 // GetDeviceEnrollmentByName retrieves a device enrollment by Name.
 func (c *Client) GetDeviceEnrollmentByName(name string) (*ResourceDeviceEnrollment, error) {
-	enrollments, err := c.GetDeviceEnrollments(url.Values{})
+	enrollments, err := c.GetDeviceEnrollments(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "device enrollments", err)
 	}

--- a/sdk/jamfpro/jamfproapi_enrollment.go
+++ b/sdk/jamfpro/jamfproapi_enrollment.go
@@ -231,7 +231,7 @@ func (c *Client) GetAccountDrivenUserEnrollmentAccessGroupByID(id string) (*Reso
 
 // GetAccountDrivenUserEnrollmentAccessGroupByName retrieves an Account Driven User Enrollment Access Group by its name
 func (c *Client) GetAccountDrivenUserEnrollmentAccessGroupByName(name string) (*ResourceAccountDrivenUserEnrollmentAccessGroup, error) {
-	accessGroupsList, err := c.GetAccountDrivenUserEnrollmentAccessGroups(url.Values{})
+	accessGroupsList, err := c.GetAccountDrivenUserEnrollmentAccessGroups(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "ADUE access group", err)
 	}

--- a/sdk/jamfpro/jamfproapi_enrollment.go
+++ b/sdk/jamfpro/jamfproapi_enrollment.go
@@ -170,7 +170,7 @@ type ResourceLanguageCode struct {
 // GetEnrollmentHistory fetches the enrollment history from the Jamf Pro API
 func (c *Client) GetEnrollmentHistory(params url.Values) (*ResponseEnrollmentHistory, error) {
 	endpoint := fmt.Sprintf("%s/history", uriEnrollmentV2)
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Enrollment History", err)
 	}
@@ -192,7 +192,7 @@ func (c *Client) GetEnrollmentHistory(params url.Values) (*ResponseEnrollmentHis
 // GetAccountDrivenUserEnrollmentAccessGroups fetches all ADUE access groups
 func (c *Client) GetAccountDrivenUserEnrollmentAccessGroups(params url.Values) (*ResponseAccountDrivenUserEnrollmentAccessGroupsList, error) {
 	endpoint := fmt.Sprintf("%s/access-groups", uriEnrollmentV3)
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "ADUE Access Group List", err)
 	}

--- a/sdk/jamfpro/jamfproapi_enrollment.go
+++ b/sdk/jamfpro/jamfproapi_enrollment.go
@@ -8,6 +8,7 @@ package jamfpro
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -167,9 +168,9 @@ type ResourceLanguageCode struct {
 // CRUD
 
 // GetEnrollmentHistory fetches the enrollment history from the Jamf Pro API
-func (c *Client) GetEnrollmentHistory(sort_filter string) (*ResponseEnrollmentHistory, error) {
+func (c *Client) GetEnrollmentHistory(params url.Values) (*ResponseEnrollmentHistory, error) {
 	endpoint := fmt.Sprintf("%s/history", uriEnrollmentV2)
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Enrollment History", err)
 	}
@@ -189,9 +190,9 @@ func (c *Client) GetEnrollmentHistory(sort_filter string) (*ResponseEnrollmentHi
 }
 
 // GetAccountDrivenUserEnrollmentAccessGroups fetches all ADUE access groups
-func (c *Client) GetAccountDrivenUserEnrollmentAccessGroups(sort_filter string) (*ResponseAccountDrivenUserEnrollmentAccessGroupsList, error) {
+func (c *Client) GetAccountDrivenUserEnrollmentAccessGroups(params url.Values) (*ResponseAccountDrivenUserEnrollmentAccessGroupsList, error) {
 	endpoint := fmt.Sprintf("%s/access-groups", uriEnrollmentV3)
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, 0, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "ADUE Access Group List", err)
 	}
@@ -230,7 +231,7 @@ func (c *Client) GetAccountDrivenUserEnrollmentAccessGroupByID(id string) (*Reso
 
 // GetAccountDrivenUserEnrollmentAccessGroupByName retrieves an Account Driven User Enrollment Access Group by its name
 func (c *Client) GetAccountDrivenUserEnrollmentAccessGroupByName(name string) (*ResourceAccountDrivenUserEnrollmentAccessGroup, error) {
-	accessGroupsList, err := c.GetAccountDrivenUserEnrollmentAccessGroups("")
+	accessGroupsList, err := c.GetAccountDrivenUserEnrollmentAccessGroups(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "ADUE access group", err)
 	}

--- a/sdk/jamfpro/jamfproapi_enrollment_customizations.go
+++ b/sdk/jamfpro/jamfproapi_enrollment_customizations.go
@@ -139,12 +139,7 @@ type EnrollmentCustomizationSubsetBrandingSettings struct {
 // Returns paginated list of Enrollment Customization
 func (c *Client) GetEnrollmentCustomizations(params url.Values) (*ResponseEnrollmentCustomizationList, error) {
 	endpoint := uriEnrollmentCustomizationSettingsV2
-	resp, err := c.DoPaginatedGet(
-		endpoint,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "enrollment customization", err)

--- a/sdk/jamfpro/jamfproapi_enrollment_customizations.go
+++ b/sdk/jamfpro/jamfproapi_enrollment_customizations.go
@@ -182,7 +182,7 @@ func (c *Client) GetEnrollmentCustomizationByID(id string) (*ResourceEnrollmentC
 
 // GetEnrollmentCustomizationByName retrieves an enrollment customization by its display name
 func (c *Client) GetEnrollmentCustomizationByName(name string) (*ResourceEnrollmentCustomization, error) {
-	customizations, err := c.GetEnrollmentCustomizations(url.Values{})
+	customizations, err := c.GetEnrollmentCustomizations(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get enrollment customizations list: %v", err)
 	}

--- a/sdk/jamfpro/jamfproapi_enrollment_customizations.go
+++ b/sdk/jamfpro/jamfproapi_enrollment_customizations.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 const uriEnrollmentCustomizationSettingsV1 = "/api/v1/enrollment-customization"
@@ -136,13 +137,13 @@ type EnrollmentCustomizationSubsetBrandingSettings struct {
 // TODO Download an image - https://developer.jamf.com/jamf-pro/reference/get_v2-enrollment-customizations-images-id
 
 // Returns paginated list of Enrollment Customization
-func (c *Client) GetEnrollmentCustomizations(sort_filter string) (*ResponseEnrollmentCustomizationList, error) {
+func (c *Client) GetEnrollmentCustomizations(params url.Values) (*ResponseEnrollmentCustomizationList, error) {
 	endpoint := uriEnrollmentCustomizationSettingsV2
 	resp, err := c.DoPaginatedGet(
 		endpoint,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -186,7 +187,7 @@ func (c *Client) GetEnrollmentCustomizationByID(id string) (*ResourceEnrollmentC
 
 // GetEnrollmentCustomizationByName retrieves an enrollment customization by its display name
 func (c *Client) GetEnrollmentCustomizationByName(name string) (*ResourceEnrollmentCustomization, error) {
-	customizations, err := c.GetEnrollmentCustomizations("")
+	customizations, err := c.GetEnrollmentCustomizations(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get enrollment customizations list: %v", err)
 	}

--- a/sdk/jamfpro/jamfproapi_gsx_connection.go
+++ b/sdk/jamfpro/jamfproapi_gsx_connection.go
@@ -142,12 +142,8 @@ Example:
 	fmt.Println(history)
 */
 func (c *Client) GetGSXConnectionHistory(params url.Values) (*ResponseGSXConnectionHistoryList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriGSXConnection,
-		maxPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriGSXConnection, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "gsx connection history", err)
 	}

--- a/sdk/jamfpro/jamfproapi_gsx_connection.go
+++ b/sdk/jamfpro/jamfproapi_gsx_connection.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -128,7 +129,7 @@ Method: GET
 Path: /api/v1/gsx-connection/history
 Description: Retrieves all GSX connection history.
 Parameters:
-  - sort_filter (string): A string specifying the sorting criteria.
+  - params (string): A string specifying the sorting criteria.
 
 Returns: ResponseGSXConnectionHistoryList - A list of GSX connection history.
 Errors: Returns an error if the request fails.
@@ -140,12 +141,12 @@ Example:
 	}
 	fmt.Println(history)
 */
-func (c *Client) GetGSXConnectionHistory(sort_filter string) (*ResponseGSXConnectionHistoryList, error) {
+func (c *Client) GetGSXConnectionHistory(params url.Values) (*ResponseGSXConnectionHistoryList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriGSXConnection,
 		maxPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "gsx connection history", err)

--- a/sdk/jamfpro/jamfproapi_jamf_connect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_connect.go
@@ -98,7 +98,7 @@ func (c *Client) GetJamfConnectConfigProfileByConfigProfileUUID(uuid string) (*R
 		return nil, fmt.Errorf("uuid cannot be empty")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
+	profiles, err := c.GetJamfConnectConfigProfiles(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}
@@ -118,7 +118,7 @@ func (c *Client) GetJamfConnectConfigProfileByID(profileID int) (*ResourceJamfCo
 		return nil, fmt.Errorf("profile ID must be greater than 0")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
+	profiles, err := c.GetJamfConnectConfigProfiles(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}
@@ -138,7 +138,7 @@ func (c *Client) GetJamfConnectConfigProfileByName(name string) (*ResourceJamfCo
 		return nil, fmt.Errorf("name cannot be empty")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
+	profiles, err := c.GetJamfConnectConfigProfiles(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}

--- a/sdk/jamfpro/jamfproapi_jamf_connect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_connect.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -97,7 +98,7 @@ func (c *Client) GetJamfConnectConfigProfileByConfigProfileUUID(uuid string) (*R
 		return nil, fmt.Errorf("uuid cannot be empty")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles("")
+	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}
@@ -117,7 +118,7 @@ func (c *Client) GetJamfConnectConfigProfileByID(profileID int) (*ResourceJamfCo
 		return nil, fmt.Errorf("profile ID must be greater than 0")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles("")
+	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}
@@ -137,7 +138,7 @@ func (c *Client) GetJamfConnectConfigProfileByName(name string) (*ResourceJamfCo
 		return nil, fmt.Errorf("name cannot be empty")
 	}
 
-	profiles, err := c.GetJamfConnectConfigProfiles("")
+	profiles, err := c.GetJamfConnectConfigProfiles(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "jamf connect config profile", err)
 	}
@@ -152,14 +153,14 @@ func (c *Client) GetJamfConnectConfigProfileByName(name string) (*ResourceJamfCo
 }
 
 // GetJamfConnectConfigProfiles gets full list of Jamf Connect config profiles & handles pagination
-func (c *Client) GetJamfConnectConfigProfiles(sort_filter string) (*ResponseJamfConnectConfigProfilesList, error) {
+func (c *Client) GetJamfConnectConfigProfiles(params url.Values) (*ResponseJamfConnectConfigProfilesList, error) {
 	endpoint := fmt.Sprintf("%s/config-profiles", uriJamfConnect)
 
 	resp, err := c.DoPaginatedGet(
 		endpoint,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {

--- a/sdk/jamfpro/jamfproapi_jamf_connect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_connect.go
@@ -156,12 +156,7 @@ func (c *Client) GetJamfConnectConfigProfileByName(name string) (*ResourceJamfCo
 func (c *Client) GetJamfConnectConfigProfiles(params url.Values) (*ResponseJamfConnectConfigProfilesList, error) {
 	endpoint := fmt.Sprintf("%s/config-profiles", uriJamfConnect)
 
-	resp, err := c.DoPaginatedGet(
-		endpoint,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "jamf connect config profiles", err)

--- a/sdk/jamfpro/jamfproapi_jamf_protect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_protect.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -173,10 +174,10 @@ func (c *Client) RetryJamfProtectInstallTasks(deploymentID string, taskIDs []str
 }
 
 // GetJamfProtectHistory retrieves the history of Jamf Protect actions
-func (c *Client) GetJamfProtectHistory(sortFilter string) (*ResponseJamfProtectHistoryList, error) {
+func (c *Client) GetJamfProtectHistory(params url.Values) (*ResponseJamfProtectHistoryList, error) {
 	endpoint := fmt.Sprintf("%s/history", uriJamfProtect)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, sortFilter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf Protect history", err)
 	}
@@ -197,10 +198,10 @@ func (c *Client) GetJamfProtectHistory(sortFilter string) (*ResponseJamfProtectH
 }
 
 // GetJamfProtectPlans retrieves all previously synced Jamf Protect Plans with their associated configuration profile information
-func (c *Client) GetJamfProtectPlans(sortFilter string) (*ResponseJamfProtectPlansList, error) {
+func (c *Client) GetJamfProtectPlans(params url.Values) (*ResponseJamfProtectPlansList, error) {
 	endpoint := fmt.Sprintf("%s/plans", uriJamfProtect)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, sortFilter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf Protect plans", err)
 	}

--- a/sdk/jamfpro/jamfproapi_jamf_protect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_protect.go
@@ -177,7 +177,7 @@ func (c *Client) RetryJamfProtectInstallTasks(deploymentID string, taskIDs []str
 func (c *Client) GetJamfProtectHistory(params url.Values) (*ResponseJamfProtectHistoryList, error) {
 	endpoint := fmt.Sprintf("%s/history", uriJamfProtect)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf Protect history", err)
 	}
@@ -201,7 +201,7 @@ func (c *Client) GetJamfProtectHistory(params url.Values) (*ResponseJamfProtectH
 func (c *Client) GetJamfProtectPlans(params url.Values) (*ResponseJamfProtectPlansList, error) {
 	endpoint := fmt.Sprintf("%s/plans", uriJamfProtect)
 
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "Jamf Protect plans", err)
 	}

--- a/sdk/jamfpro/jamfproapi_managed_software_updates.go
+++ b/sdk/jamfpro/jamfproapi_managed_software_updates.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -164,12 +165,12 @@ func (c *Client) GetManagedSoftwareUpdates() (*ResponseManagedSoftwareUpdateList
 }
 
 // GetManagedSoftwareUpdatePlans retrieves a list of all available managed software updates
-func (c *Client) GetManagedSoftwareUpdatePlans(sort_filter string) (*ResponseManagedSoftwareUpdatePlanList, error) {
+func (c *Client) GetManagedSoftwareUpdatePlans(params url.Values) (*ResponseManagedSoftwareUpdatePlanList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriManagedSoftwareUpdates+"/plans",
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {

--- a/sdk/jamfpro/jamfproapi_managed_software_updates.go
+++ b/sdk/jamfpro/jamfproapi_managed_software_updates.go
@@ -166,12 +166,7 @@ func (c *Client) GetManagedSoftwareUpdates() (*ResponseManagedSoftwareUpdateList
 
 // GetManagedSoftwareUpdatePlans retrieves a list of all available managed software updates
 func (c *Client) GetManagedSoftwareUpdatePlans(params url.Values) (*ResponseManagedSoftwareUpdatePlanList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriManagedSoftwareUpdates+"/plans",
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriManagedSoftwareUpdates+"/plans", params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "managed software update plans", err)

--- a/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
+++ b/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
@@ -133,7 +133,7 @@ type MobileDevicePrestageSubsetNamesName struct {
 // GetMobileDevicePrestages retrieves a list of all mobile prestages
 func (c *Client) GetMobileDevicePrestages(params url.Values) (*ResponseMobileDevicePrestagesList, error) {
 	endpoint := uriMobileDevicePrestages
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(endpoint, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "mobile device prestages", err)
 	}

--- a/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
+++ b/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -130,9 +131,9 @@ type MobileDevicePrestageSubsetNamesName struct {
 // CRUD
 
 // GetMobileDevicePrestages retrieves a list of all mobile prestages
-func (c *Client) GetMobileDevicePrestages(sort_filter string) (*ResponseMobileDevicePrestagesList, error) {
+func (c *Client) GetMobileDevicePrestages(params url.Values) (*ResponseMobileDevicePrestagesList, error) {
 	endpoint := uriMobileDevicePrestages
-	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, sort_filter)
+	resp, err := c.DoPaginatedGet(endpoint, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "mobile device prestages", err)
 	}

--- a/sdk/jamfpro/jamfproapi_patch_policies.go
+++ b/sdk/jamfpro/jamfproapi_patch_policies.go
@@ -9,6 +9,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -134,12 +135,12 @@ type ResourcePatchPolicyCreateRequestGracePeriod struct {
 // CRUD
 
 // GetPatchPolicies gets the full list of patch policies & handles pagination
-func (c *Client) GetPatchPolicies(sortFilter string) (*ResponsePatchPoliciesList, error) {
+func (c *Client) GetPatchPolicies(params url.Values) (*ResponsePatchPoliciesList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriPatchPoliciesJamfProAPI+"/policy-details",
 		standardPageSize,
 		startingPageNumber,
-		sortFilter,
+		params,
 	)
 
 	if err != nil {
@@ -167,7 +168,7 @@ func (c *Client) GetPatchPolicyByID(id string) (*ResourcePatchPolicyJamfProAPI, 
 		return nil, fmt.Errorf("patch policy ID cannot be empty")
 	}
 
-	policies, err := c.GetPatchPolicies("")
+	policies, err := c.GetPatchPolicies(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "patch policy", err)
 	}
@@ -187,7 +188,7 @@ func (c *Client) GetPatchPolicyByName(name string) (*ResourcePatchPolicyJamfProA
 		return nil, fmt.Errorf("patch policy name cannot be empty")
 	}
 
-	policies, err := c.GetPatchPolicies("")
+	policies, err := c.GetPatchPolicies(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "patch policy", err)
 	}

--- a/sdk/jamfpro/jamfproapi_patch_policies.go
+++ b/sdk/jamfpro/jamfproapi_patch_policies.go
@@ -163,7 +163,7 @@ func (c *Client) GetPatchPolicyByID(id string) (*ResourcePatchPolicyJamfProAPI, 
 		return nil, fmt.Errorf("patch policy ID cannot be empty")
 	}
 
-	policies, err := c.GetPatchPolicies(url.Values{})
+	policies, err := c.GetPatchPolicies(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "patch policy", err)
 	}
@@ -183,7 +183,7 @@ func (c *Client) GetPatchPolicyByName(name string) (*ResourcePatchPolicyJamfProA
 		return nil, fmt.Errorf("patch policy name cannot be empty")
 	}
 
-	policies, err := c.GetPatchPolicies(url.Values{})
+	policies, err := c.GetPatchPolicies(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "patch policy", err)
 	}

--- a/sdk/jamfpro/jamfproapi_patch_policies.go
+++ b/sdk/jamfpro/jamfproapi_patch_policies.go
@@ -136,12 +136,7 @@ type ResourcePatchPolicyCreateRequestGracePeriod struct {
 
 // GetPatchPolicies gets the full list of patch policies & handles pagination
 func (c *Client) GetPatchPolicies(params url.Values) (*ResponsePatchPoliciesList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriPatchPoliciesJamfProAPI+"/policy-details",
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriPatchPoliciesJamfProAPI+"/policy-details", params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "patch policies", err)

--- a/sdk/jamfpro/jamfproapi_patch_software_title_configurations.go
+++ b/sdk/jamfpro/jamfproapi_patch_software_title_configurations.go
@@ -163,12 +163,8 @@ func (c *Client) GetPatchSoftwareTitleDefinitions(id string, params url.Values) 
 
 	endpoint := fmt.Sprintf("%s/%s/definitions", uriPatchSoftwareTitleConfigurations, id)
 
-	resp, err := c.DoPaginatedGet(
-		endpoint,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(endpoint, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "patch software title definitions", err)
 	}

--- a/sdk/jamfpro/jamfproapi_patch_software_title_configurations.go
+++ b/sdk/jamfpro/jamfproapi_patch_software_title_configurations.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -155,7 +156,7 @@ func (c *Client) GetPatchSoftwareTitleConfigurationByName(name string) (*Resourc
 }
 
 // GetPatchSoftwareTitleDefinitions retrieves patch software title definitions with the supplied id
-func (c *Client) GetPatchSoftwareTitleDefinitions(id string, sortFilter string) (*ResponsePatchSoftwareTitleDefinitionsList, error) {
+func (c *Client) GetPatchSoftwareTitleDefinitions(id string, params url.Values) (*ResponsePatchSoftwareTitleDefinitionsList, error) {
 	if id == "" {
 		return nil, fmt.Errorf("patch software title id cannot be empty")
 	}
@@ -166,7 +167,7 @@ func (c *Client) GetPatchSoftwareTitleDefinitions(id string, sortFilter string) 
 		endpoint,
 		standardPageSize,
 		startingPageNumber,
-		sortFilter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "patch software title definitions", err)

--- a/sdk/jamfpro/jamfproapi_scripts.go
+++ b/sdk/jamfpro/jamfproapi_scripts.go
@@ -57,12 +57,7 @@ type ResourceScript struct {
 
 // Gets full list of scripts & handles pagination
 func (c *Client) GetScripts(params url.Values) (*ResponseScriptsList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriScripts,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriScripts, params)
 
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "scripts", err)

--- a/sdk/jamfpro/jamfproapi_scripts.go
+++ b/sdk/jamfpro/jamfproapi_scripts.go
@@ -98,7 +98,7 @@ func (c *Client) GetScriptByID(id string) (*ResourceScript, error) {
 
 // Retrieves script by Name by leveraging GetScripts(), returns ResourceScript
 func (c *Client) GetScriptByName(name string) (*ResourceScript, error) {
-	scripts, err := c.GetScripts(url.Values{})
+	scripts, err := c.GetScripts(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "scripts", err)
 	}

--- a/sdk/jamfpro/jamfproapi_scripts.go
+++ b/sdk/jamfpro/jamfproapi_scripts.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -55,12 +56,12 @@ type ResourceScript struct {
 // CRUD
 
 // Gets full list of scripts & handles pagination
-func (c *Client) GetScripts(sort_filter string) (*ResponseScriptsList, error) {
+func (c *Client) GetScripts(params url.Values) (*ResponseScriptsList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriScripts,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 
 	if err != nil {
@@ -102,7 +103,7 @@ func (c *Client) GetScriptByID(id string) (*ResourceScript, error) {
 
 // Retrieves script by Name by leveraging GetScripts(), returns ResourceScript
 func (c *Client) GetScriptByName(name string) (*ResourceScript, error) {
-	scripts, err := c.GetScripts("")
+	scripts, err := c.GetScripts(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "scripts", err)
 	}

--- a/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
+++ b/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -38,12 +39,12 @@ type ResourceSelfServiceBrandingDetail struct {
 // CRUD
 
 // GetSelfServiceBrandingMacOS retrieves the list of self-service branding configurations for macOS.
-func (c *Client) GetSelfServiceBrandingMacOS(sort_filter string) (*ResponseSelfServiceBrandingList, error) {
+func (c *Client) GetSelfServiceBrandingMacOS(params url.Values) (*ResponseSelfServiceBrandingList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriSelfServiceBrandingMacOS,
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "self service branding", err)
@@ -85,7 +86,7 @@ func (c *Client) GetSelfServiceBrandingMacOSByID(id string) (*ResourceSelfServic
 
 // GetSelfServiceBrandingMacOSByNameByID retrieves a specific self-service branding configuration for macOS by its name.
 func (c *Client) GetSelfServiceBrandingMacOSByName(name string) (*ResourceSelfServiceBrandingDetail, error) {
-	all_ssbrandings, err := c.GetSelfServiceBrandingMacOS("")
+	all_ssbrandings, err := c.GetSelfServiceBrandingMacOS(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "self service brandings", err)
 	}

--- a/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
+++ b/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
@@ -82,7 +82,7 @@ func (c *Client) GetSelfServiceBrandingMacOSByID(id string) (*ResourceSelfServic
 
 // GetSelfServiceBrandingMacOSByNameByID retrieves a specific self-service branding configuration for macOS by its name.
 func (c *Client) GetSelfServiceBrandingMacOSByName(name string) (*ResourceSelfServiceBrandingDetail, error) {
-	all_ssbrandings, err := c.GetSelfServiceBrandingMacOS(url.Values{})
+	all_ssbrandings, err := c.GetSelfServiceBrandingMacOS(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "self service brandings", err)
 	}

--- a/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
+++ b/sdk/jamfpro/jamfproapi_self_service_branding_macos.go
@@ -40,12 +40,8 @@ type ResourceSelfServiceBrandingDetail struct {
 
 // GetSelfServiceBrandingMacOS retrieves the list of self-service branding configurations for macOS.
 func (c *Client) GetSelfServiceBrandingMacOS(params url.Values) (*ResponseSelfServiceBrandingList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriSelfServiceBrandingMacOS,
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriSelfServiceBrandingMacOS, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "self service branding", err)
 	}

--- a/sdk/jamfpro/jamfproapi_smart_computer_groups.go
+++ b/sdk/jamfpro/jamfproapi_smart_computer_groups.go
@@ -12,6 +12,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -104,12 +105,12 @@ func (c *Client) GetSmartComputerGroupMembershipByID(id string) (*ResponseSmartC
 }
 
 // GetSmartComputerGroupsV2 retrieves a paginated list of all Smart Computer Groups using V2 API
-func (c *Client) GetSmartComputerGroupsV2(sort_filter string) (*ResponseSmartComputerGroupsListV2, error) {
+func (c *Client) GetSmartComputerGroupsV2(params url.Values) (*ResponseSmartComputerGroupsListV2, error) {
 	resp, err := c.DoPaginatedGet(
 		fmt.Sprintf("%s/smart-groups", uriAPIV2SmartComputerGroups),
 		standardPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "smart computer groups", err)

--- a/sdk/jamfpro/jamfproapi_smart_computer_groups.go
+++ b/sdk/jamfpro/jamfproapi_smart_computer_groups.go
@@ -106,12 +106,7 @@ func (c *Client) GetSmartComputerGroupMembershipByID(id string) (*ResponseSmartC
 
 // GetSmartComputerGroupsV2 retrieves a paginated list of all Smart Computer Groups using V2 API
 func (c *Client) GetSmartComputerGroupsV2(params url.Values) (*ResponseSmartComputerGroupsListV2, error) {
-	resp, err := c.DoPaginatedGet(
-		fmt.Sprintf("%s/smart-groups", uriAPIV2SmartComputerGroups),
-		standardPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(fmt.Sprintf("%s/smart-groups", uriAPIV2SmartComputerGroups), params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "smart computer groups", err)
 	}

--- a/sdk/jamfpro/jamfproapi_volume_purchasing_locations.go
+++ b/sdk/jamfpro/jamfproapi_volume_purchasing_locations.go
@@ -79,8 +79,8 @@ type VolumePurchasingSubsetContent struct {
 // VPP Locations
 
 // GetVolumePurchaseLocations retrieves all volume purchasing locations with optional sorting and filtering.
-func (c *Client) GetVolumePurchaseLocations(sort_filter string) (*ResponseVolumePurchasingList, error) {
-	resp, err := c.DoPaginatedGet(uriVolumePurchasingLocations, standardPageSize, startingPageNumber, sort_filter)
+func (c *Client) GetVolumePurchaseLocations(params url.Values) (*ResponseVolumePurchasingList, error) {
+	resp, err := c.DoPaginatedGet(uriVolumePurchasingLocations, standardPageSize, startingPageNumber, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "vpp locations", err)
 	}

--- a/sdk/jamfpro/jamfproapi_volume_purchasing_locations.go
+++ b/sdk/jamfpro/jamfproapi_volume_purchasing_locations.go
@@ -80,7 +80,7 @@ type VolumePurchasingSubsetContent struct {
 
 // GetVolumePurchaseLocations retrieves all volume purchasing locations with optional sorting and filtering.
 func (c *Client) GetVolumePurchaseLocations(params url.Values) (*ResponseVolumePurchasingList, error) {
-	resp, err := c.DoPaginatedGet(uriVolumePurchasingLocations, standardPageSize, startingPageNumber, params)
+	resp, err := c.DoPaginatedGet(uriVolumePurchasingLocations, params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "vpp locations", err)
 	}

--- a/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
+++ b/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
@@ -7,6 +7,7 @@ package jamfpro
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -48,12 +49,12 @@ type VolumePurchasingSubscriptionSubsetExternalRecipients struct {
 // CRUD
 
 // GetVolumePurchasingSubscriptions retrieves all volume purchasing subscriptions
-func (c *Client) GetVolumePurchasingSubscriptions(sort_filter string) (*ResponseVolumePurchasingSubscriptionsList, error) {
+func (c *Client) GetVolumePurchasingSubscriptions(params url.Values) (*ResponseVolumePurchasingSubscriptionsList, error) {
 	resp, err := c.DoPaginatedGet(
 		uriVolumePurchasingSubscriptions,
 		maxPageSize,
 		startingPageNumber,
-		sort_filter,
+		params,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "volume purchasing subscriptions", err)
@@ -93,7 +94,7 @@ func (c *Client) GetVolumePurchasingSubscriptionByID(id string) (*ResourceVolume
 
 // GetVolumePurchasingSubscriptionByNameByID fetches a volume purchasing subscription by its display name and retrieves its details using its ID.
 func (c *Client) GetVolumePurchasingSubscriptionByName(name string) (*ResourceVolumePurchasingSubscription, error) {
-	vpSubcriptions, err := c.GetVolumePurchasingSubscriptions("")
+	vpSubcriptions, err := c.GetVolumePurchasingSubscriptions(url.Values{})
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "volume purchasing subscriptions", err)
 	}

--- a/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
+++ b/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
@@ -90,7 +90,7 @@ func (c *Client) GetVolumePurchasingSubscriptionByID(id string) (*ResourceVolume
 
 // GetVolumePurchasingSubscriptionByNameByID fetches a volume purchasing subscription by its display name and retrieves its details using its ID.
 func (c *Client) GetVolumePurchasingSubscriptionByName(name string) (*ResourceVolumePurchasingSubscription, error) {
-	vpSubcriptions, err := c.GetVolumePurchasingSubscriptions(url.Values{})
+	vpSubcriptions, err := c.GetVolumePurchasingSubscriptions(nil)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "volume purchasing subscriptions", err)
 	}

--- a/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
+++ b/sdk/jamfpro/jamfproapi_volume_purchasing_subscriptions.go
@@ -50,12 +50,8 @@ type VolumePurchasingSubscriptionSubsetExternalRecipients struct {
 
 // GetVolumePurchasingSubscriptions retrieves all volume purchasing subscriptions
 func (c *Client) GetVolumePurchasingSubscriptions(params url.Values) (*ResponseVolumePurchasingSubscriptionsList, error) {
-	resp, err := c.DoPaginatedGet(
-		uriVolumePurchasingSubscriptions,
-		maxPageSize,
-		startingPageNumber,
-		params,
-	)
+	resp, err := c.DoPaginatedGet(uriVolumePurchasingSubscriptions, params)
+
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "volume purchasing subscriptions", err)
 	}

--- a/sdk/jamfpro/shared_constants.go
+++ b/sdk/jamfpro/shared_constants.go
@@ -2,6 +2,6 @@ package jamfpro
 
 const (
 	maxPageSize        = 2000 // Maximum number of items per page
-	startingPageNumber = 0
-	standardPageSize   = 200
+	startingPageNumber = 1
+	standardPageSize   = 100
 )

--- a/sdk/jamfpro/shared_constants.go
+++ b/sdk/jamfpro/shared_constants.go
@@ -1,7 +1,6 @@
 package jamfpro
 
 const (
-	maxPageSize        = 2000 // Maximum number of items per page
-	startingPageNumber = 1
-	standardPageSize   = 100
+	startingPageNumber = "0"
+	standardPageSize   = "100"
 )

--- a/sdk/jamfpro/shared_constants.go
+++ b/sdk/jamfpro/shared_constants.go
@@ -1,6 +1,0 @@
-package jamfpro
-
-const (
-	startingPageNumber = "0"
-	standardPageSize   = "100"
-)

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -33,7 +33,7 @@ func (c *Client) DoPaginatedGet(
 	}
 
 	if params.Get("page") == "" {
-		// Some warning logic should be here
+		// Some warning log should be here
 		params.Add("page", startingPageNumber)
 	}
 

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -56,7 +56,7 @@ func (c *Client) DoPaginatedGet(
 	var page = startingPageNumber
 
 	for {
-		endpoint := fmt.Sprintf("%s?page=%d&page-size=%d%s", endpoint_root, startingPageNumber, maxPageSize, params)
+		endpoint := fmt.Sprintf("%s?%s", endpoint_root, params.Encode())
 		log.Printf("DEBUG: Fetching from endpoint: %s", endpoint)
 		resp, err := c.HTTP.DoRequest(
 			"GET",

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -13,33 +13,16 @@ type StandardPaginatedResponse struct {
 	Results []interface{} `json:"results"`
 }
 
-// DoPaginatedGet performs a paginated GET request to a specified endpoint in the Jamf Pro API.
+// DoPaginatedGet retrieves paginated results from a Jamf Pro API endpoint.
 //
-// This method is designed to fetch data in a paginated manner from Jamf Pro's RESTful API. It constructs
-// the API endpoint using the provided parameters, handles the pagination logic, and accumulates the results
-// into a single response structure. It's particularly useful for endpoints where the response is expected to
-// contain a large number of items that might be paginated by the server.
+// It constructs the request with optional sorting and pagination parameters, performs repeated GETs
+// until all pages are fetched (based on reported total size or final page), and accumulates results.
 //
 // Parameters:
-//   - endpoint_root: The root URL of the API endpoint. This is the base URL to which pagination and sorting
-//     parameters will be appended.
-//   - maxPageSize: Maximum number of items to be fetched in each paginated request. If set to 0, defaults to 200.
-//   - startingPageNumber: The page number from which to start the paginated fetching.
-//   - params: A string specifying the sorting criteria. It follows the format
-//     'sort=<field_name>[:sort_direction][,<secondary_sort_field_name>[:sort_direction]]*'. The default sort
-//     direction is 'asc' (Ascending). Use 'desc' for Descending ordering. Additional sort parameters are
-//     supported and determine the order of results that have equivalent values for previous sort parameters.
+//   - endpoint_root: Base URL for the API resource.
+//   - params: Query parameters including optional "page", "page-size", and "sort".
 //
-// The method returns a pointer to a StandardPaginatedResponse containing the aggregated results from all
-// fetched pages, or an error if the fetch operation fails at any point.
-//
-// Example usage:
-// client.GetSelfServiceBrandingMacOS("sort=id:desc")
-//
-// Note:
-// The method appends the results from each page to a slice and breaks the loop when the total number of items
-// fetched matches the reported total count from the server, or when a fetched page contains fewer items than
-// the maximum page size, indicating that it is the last page.
+// Returns a combined StandardPaginatedResponse or an error if a request fails.
 func (c *Client) DoPaginatedGet(
 	endpoint_root string,
 	params url.Values,

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -31,12 +31,12 @@ func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*Stand
 
 	if params.Get("page") == "" {
 		// Some warning log should be here
-		params.Add("page", startingPageNumber)
+		params.Add("page", "0")
 	}
 
 	if params.Get("page-size") == "" {
 		// and here
-		params.Add("page-size", standardPageSize)
+		params.Add("page-size", "100")
 	}
 
 	var outStruct StandardPaginatedResponse

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -23,10 +23,7 @@ type StandardPaginatedResponse struct {
 //   - params: Query parameters including optional "page", "page-size", and "sort".
 //
 // Returns a combined StandardPaginatedResponse or an error if a request fails.
-func (c *Client) DoPaginatedGet(
-	endpoint_root string,
-	params url.Values,
-) (*StandardPaginatedResponse, error) {
+func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*StandardPaginatedResponse, error) {
 
 	if params == nil {
 		params = url.Values{}

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -49,6 +49,7 @@ func (c *Client) DoPaginatedGet(
 
 	params.Add("page", strconv.Itoa(startingPageNumber))
 	params.Add("page-size", strconv.Itoa(maxPageSize))
+	encodedParams := params.Encode()
 
 	var OutStruct StandardPaginatedResponse
 	var TargetObjectAccumulator StandardPaginatedResponse
@@ -56,7 +57,7 @@ func (c *Client) DoPaginatedGet(
 	var page = startingPageNumber
 
 	for {
-		endpoint := fmt.Sprintf("%s?%s", endpoint_root, params.Encode())
+		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
 		log.Printf("DEBUG: Fetching from endpoint: %s", endpoint)
 		resp, err := c.HTTP.DoRequest(
 			"GET",

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -47,6 +47,10 @@ func (c *Client) DoPaginatedGet(
 	params url.Values,
 ) (*StandardPaginatedResponse, error) {
 
+	if params == nil {
+		params = url.Values{}
+	}
+
 	params.Add("page", strconv.Itoa(startingPageNumber))
 	params.Add("page-size", strconv.Itoa(maxPageSize))
 	encodedParams := params.Encode()

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -4,7 +4,6 @@ package jamfpro
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"strconv"
 )
@@ -53,7 +52,6 @@ func (c *Client) DoPaginatedGet(
 
 	params.Add("page", strconv.Itoa(startingPageNumber))
 	params.Add("page-size", strconv.Itoa(maxPageSize))
-	encodedParams := params.Encode()
 
 	var OutStruct StandardPaginatedResponse
 	var TargetObjectAccumulator StandardPaginatedResponse
@@ -61,8 +59,8 @@ func (c *Client) DoPaginatedGet(
 	var page = startingPageNumber
 
 	for {
+		encodedParams := params.Encode()
 		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
-		log.Printf("DEBUG: Fetching from endpoint: %s", endpoint)
 		resp, err := c.HTTP.DoRequest(
 			"GET",
 			endpoint,
@@ -87,6 +85,8 @@ func (c *Client) DoPaginatedGet(
 		}
 
 		page++
+		params.Del("page")
+		params.Add("page", strconv.Itoa(page))
 
 	}
 

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -5,6 +5,8 @@ package jamfpro
 import (
 	"fmt"
 	"log"
+	"net/url"
+	"strconv"
 )
 
 type StandardPaginatedResponse struct {
@@ -24,7 +26,7 @@ type StandardPaginatedResponse struct {
 //     parameters will be appended.
 //   - maxPageSize: Maximum number of items to be fetched in each paginated request. If set to 0, defaults to 200.
 //   - startingPageNumber: The page number from which to start the paginated fetching.
-//   - sort_filter: A string specifying the sorting criteria. It follows the format
+//   - params: A string specifying the sorting criteria. It follows the format
 //     'sort=<field_name>[:sort_direction][,<secondary_sort_field_name>[:sort_direction]]*'. The default sort
 //     direction is 'asc' (Ascending). Use 'desc' for Descending ordering. Additional sort parameters are
 //     supported and determine the order of results that have equivalent values for previous sort parameters.
@@ -42,12 +44,11 @@ type StandardPaginatedResponse struct {
 func (c *Client) DoPaginatedGet(
 	endpoint_root string,
 	maxPageSize, startingPageNumber int,
-	sort_filter string,
+	params url.Values,
 ) (*StandardPaginatedResponse, error) {
 
-	if maxPageSize == 0 {
-		maxPageSize = 200
-	}
+	params.Add("page", strconv.Itoa(startingPageNumber))
+	params.Add("page-size", strconv.Itoa(maxPageSize))
 
 	var OutStruct StandardPaginatedResponse
 	var TargetObjectAccumulator StandardPaginatedResponse
@@ -55,7 +56,7 @@ func (c *Client) DoPaginatedGet(
 	var page = startingPageNumber
 
 	for {
-		endpoint := fmt.Sprintf("%s?page=%d&page-size=%d%s", endpoint_root, startingPageNumber, maxPageSize, sort_filter)
+		endpoint := fmt.Sprintf("%s?page=%d&page-size=%d%s", endpoint_root, startingPageNumber, maxPageSize, params)
 		log.Printf("DEBUG: Fetching from endpoint: %s", endpoint)
 		resp, err := c.HTTP.DoRequest(
 			"GET",

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -55,6 +55,7 @@ func (c *Client) DoPaginatedGet(
 		TargetObjectAccumulator := StandardPaginatedResponse{}
 		encodedParams := params.Encode()
 		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
+
 		resp, err := c.HTTP.DoRequest(
 			"GET",
 			endpoint,

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -42,7 +42,6 @@ type StandardPaginatedResponse struct {
 // the maximum page size, indicating that it is the last page.
 func (c *Client) DoPaginatedGet(
 	endpoint_root string,
-	maxPageSize, startingPageNumber int,
 	params url.Values,
 ) (*StandardPaginatedResponse, error) {
 
@@ -51,17 +50,23 @@ func (c *Client) DoPaginatedGet(
 	}
 
 	if params.Get("page") == "" {
-		params.Add("page", strconv.Itoa(startingPageNumber))
+		// Some warning logic should be here
+		params.Add("page", startingPageNumber)
 	}
 
 	if params.Get("page-size") == "" {
-		params.Add("page-size", strconv.Itoa(maxPageSize))
+		// and here
+		params.Add("page-size", standardPageSize)
 	}
 
 	var OutStruct StandardPaginatedResponse
 	var TargetObjectAccumulator StandardPaginatedResponse
 	var OutData []interface{}
-	var page = startingPageNumber
+	var page, err = strconv.Atoi(params.Get("page"))
+
+	if err != nil {
+		return nil, fmt.Errorf("error getting page number: %v", err)
+	}
 
 	for {
 		TargetObjectAccumulator := StandardPaginatedResponse{}
@@ -85,7 +90,6 @@ func (c *Client) DoPaginatedGet(
 		OutData = append(OutData, TargetObjectAccumulator.Results...)
 
 		if len(OutData) >= TargetObjectAccumulator.Size ||
-			len(TargetObjectAccumulator.Results) < maxPageSize ||
 			len(TargetObjectAccumulator.Results) == 0 {
 			break
 		}

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -71,7 +71,7 @@ func (c *Client) DoPaginatedGet(
 			"GET",
 			endpoint,
 			nil,
-			TargetObjectAccumulator,
+			&TargetObjectAccumulator,
 		)
 
 		if err != nil {

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -64,13 +64,14 @@ func (c *Client) DoPaginatedGet(
 	var page = startingPageNumber
 
 	for {
+		TargetObjectAccumulator := StandardPaginatedResponse{}
 		encodedParams := params.Encode()
 		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
 		resp, err := c.HTTP.DoRequest(
 			"GET",
 			endpoint,
 			nil,
-			&TargetObjectAccumulator,
+			TargetObjectAccumulator,
 		)
 
 		if err != nil {

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -50,8 +50,13 @@ func (c *Client) DoPaginatedGet(
 		params = url.Values{}
 	}
 
-	params.Add("page", strconv.Itoa(startingPageNumber))
-	params.Add("page-size", strconv.Itoa(maxPageSize))
+	if params.Get("page") == "" {
+		params.Add("page", strconv.Itoa(startingPageNumber))
+	}
+
+	if params.Get("page-size") == "" {
+		params.Add("page-size", strconv.Itoa(maxPageSize))
+	}
 
 	var OutStruct StandardPaginatedResponse
 	var TargetObjectAccumulator StandardPaginatedResponse

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -48,7 +48,7 @@ func (c *Client) DoPaginatedGet(
 	var page, err = strconv.Atoi(params.Get("page"))
 
 	if err != nil {
-		return nil, fmt.Errorf("error getting page number: %v", err)
+		return nil, fmt.Errorf("error converting page number: %v", err)
 	}
 
 	for {
@@ -64,7 +64,7 @@ func (c *Client) DoPaginatedGet(
 		)
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch obj %v", err)
+			return nil, fmt.Errorf("failed to fetch page %v", err)
 		}
 
 		if resp != nil {

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -42,9 +42,9 @@ func (c *Client) DoPaginatedGet(
 		params.Add("page-size", standardPageSize)
 	}
 
-	var OutStruct StandardPaginatedResponse
-	var TargetObjectAccumulator StandardPaginatedResponse
-	var OutData []interface{}
+	var outStruct StandardPaginatedResponse
+	var targetObjectAccumulator StandardPaginatedResponse
+	var outData []interface{}
 	var page, err = strconv.Atoi(params.Get("page"))
 
 	if err != nil {
@@ -52,7 +52,7 @@ func (c *Client) DoPaginatedGet(
 	}
 
 	for {
-		TargetObjectAccumulator := StandardPaginatedResponse{}
+		targetObjectAccumulator := StandardPaginatedResponse{}
 		encodedParams := params.Encode()
 		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
 
@@ -60,7 +60,7 @@ func (c *Client) DoPaginatedGet(
 			"GET",
 			endpoint,
 			nil,
-			&TargetObjectAccumulator,
+			&targetObjectAccumulator,
 		)
 
 		if err != nil {
@@ -71,10 +71,10 @@ func (c *Client) DoPaginatedGet(
 			defer resp.Body.Close()
 		}
 
-		OutData = append(OutData, TargetObjectAccumulator.Results...)
+		outData = append(outData, targetObjectAccumulator.Results...)
 
-		if len(OutData) >= TargetObjectAccumulator.Size ||
-			len(TargetObjectAccumulator.Results) == 0 {
+		if len(outData) >= targetObjectAccumulator.Size ||
+			len(targetObjectAccumulator.Results) == 0 {
 			break
 		}
 
@@ -84,9 +84,9 @@ func (c *Client) DoPaginatedGet(
 
 	}
 
-	OutStruct.Size = TargetObjectAccumulator.Size
-	OutStruct.Results = OutData
+	outStruct.Size = targetObjectAccumulator.Size
+	outStruct.Results = outData
 
-	return &OutStruct, nil
+	return &outStruct, nil
 
 }

--- a/sdk/jamfpro/util_pagination.go
+++ b/sdk/jamfpro/util_pagination.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-type StandardPaginatedResponse struct {
+type ResponsePaginated struct {
 	Size    int           `json:"totalCount"`
 	Results []interface{} `json:"results"`
 }
@@ -23,7 +23,7 @@ type StandardPaginatedResponse struct {
 //   - params: Query parameters including optional "page", "page-size", and "sort".
 //
 // Returns a combined StandardPaginatedResponse or an error if a request fails.
-func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*StandardPaginatedResponse, error) {
+func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*ResponsePaginated, error) {
 
 	if params == nil {
 		params = url.Values{}
@@ -39,8 +39,8 @@ func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*Stand
 		params.Add("page-size", "100")
 	}
 
-	var outStruct StandardPaginatedResponse
-	var targetObjectAccumulator StandardPaginatedResponse
+	var outStruct ResponsePaginated
+	var targetObjectAccumulator ResponsePaginated
 	var outData []interface{}
 	var page, err = strconv.Atoi(params.Get("page"))
 
@@ -49,7 +49,7 @@ func (c *Client) DoPaginatedGet(endpoint_root string, params url.Values) (*Stand
 	}
 
 	for {
-		targetObjectAccumulator := StandardPaginatedResponse{}
+		targetObjectAccumulator := ResponsePaginated{}
 		encodedParams := params.Encode()
 		endpoint := fmt.Sprintf("%s?%s", endpoint_root, encodedParams)
 


### PR DESCRIPTION
# Change

Paginated functions now accept a url.Values{} type for pro API filtering.

Breaking change as previously only a string was accepted.

Reminder on how to structure a RSQL query:
https://developer.jamf.com/jamf-pro/docs/filtering-with-rsql

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
