### PR TITLE
feat: add membership scoping optimization field to LDAPServerSubsetMappingUserGroupMemberships

### DIFF
--- a/sdk/jamfpro/classicapi_ldap_servers.go
+++ b/sdk/jamfpro/classicapi_ldap_servers.go
@@ -109,6 +109,7 @@ type LDAPServerSubsetMappingUserGroupMemberships struct {
 	Username                          string `xml:"username"`
 	GroupID                           string `xml:"group_id"`
 	UserGroupMembershipUseLDAPCompare bool   `xml:"user_group_membership_use_ldap_compare"`
+	MembershipScopingOptimization     bool   `xml:"membership_scoping_optimization"`
 }
 
 // CRUD


### PR DESCRIPTION
# Change

Add missing membership scoping optimization field to LDAPServerSubsetMappingUserGroupMemberships

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
