### PR TITLE
fix: Add missing fields to ldapservers and existing field mappings/data type corrections

### DIFF
--- a/examples/ldap_servers/CreateLDAPServer/CreateLDAPServer.go
+++ b/examples/ldap_servers/CreateLDAPServer/CreateLDAPServer.go
@@ -50,7 +50,7 @@ func main() {
 				MapDepartment:            "department",
 				MapBuilding:              "streetAddress",
 				MapRoom:                  "room",
-				MapTelephone:             "telephoneNumber",
+				MapPhone:                 "telephoneNumber",
 				MapPosition:              "title",
 				MapUserUUID:              "objectGUID",
 				// Additional fields if necessary...
@@ -71,7 +71,7 @@ func main() {
 				AppendToUsername:                  "company.com",
 				UseDN:                             true,
 				RecursiveLookups:                  true,
-				MapUserMembershipToGroupField:     true,
+				MapUserMembershipToGroupField:     "member",
 				MapUserMembershipUseDN:            true,
 				MapObjectClassToAnyOrAll:          "all",
 				ObjectClasses:                     "group",

--- a/examples/ldap_servers/UpdateLDAPServerByID/UpdateLDAPServerByID.go
+++ b/examples/ldap_servers/UpdateLDAPServerByID/UpdateLDAPServerByID.go
@@ -51,7 +51,7 @@ func main() {
 				MapDepartment:            "department",
 				MapBuilding:              "streetAddress",
 				MapRoom:                  "room",
-				MapTelephone:             "telephoneNumber",
+				MapPhone:                 "telephoneNumber",
 				MapPosition:              "title",
 				MapUserUUID:              "objectGUID",
 				// Additional fields if necessary...
@@ -72,7 +72,7 @@ func main() {
 				AppendToUsername:                  "company.com",
 				UseDN:                             true,
 				RecursiveLookups:                  true,
-				MapUserMembershipToGroupField:     true,
+				MapUserMembershipToGroupField:     "member",
 				MapUserMembershipUseDN:            true,
 				MapObjectClassToAnyOrAll:          "all",
 				ObjectClasses:                     "group",

--- a/examples/ldap_servers/UpdateLDAPServerByName/UpdateLDAPServerByName.go
+++ b/examples/ldap_servers/UpdateLDAPServerByName/UpdateLDAPServerByName.go
@@ -51,7 +51,7 @@ func main() {
 				MapDepartment:            "department",
 				MapBuilding:              "streetAddress",
 				MapRoom:                  "room",
-				MapTelephone:             "telephoneNumber",
+				MapPhone:                 "telephoneNumber",
 				MapPosition:              "title",
 				MapUserUUID:              "objectGUID",
 				// Additional fields if necessary...
@@ -72,7 +72,7 @@ func main() {
 				AppendToUsername:                  "company.com",
 				UseDN:                             true,
 				RecursiveLookups:                  true,
-				MapUserMembershipToGroupField:     true,
+				MapUserMembershipToGroupField:     "member",
 				MapUserMembershipUseDN:            true,
 				MapObjectClassToAnyOrAll:          "all",
 				ObjectClasses:                     "group",


### PR DESCRIPTION
# Change

* Change non-existent `map_telephone` field to `map_phone` and corresponding `MapTelephone` to `MapPhone` for Go.
* Correct data type for `MapUserMembershipToGroupField` to string
* Add missing `GroupMembershipEnabledWhenUserMembershipSelected` bool
* Ensure we get the object ID when `CreateLDAPServer` is successful - refactor function to deal with API quirk (ID is not in root of XML object so does not line up with response body).
* Have tested create/update/delete with the upcoming provider resource I'll submit shortly - all working!

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
