### PR TITLE
fix: mobile_device_prestages updates

### DIFF
--- a/examples/mobile_device_prestages/CreateMobileDevicePrestage/CreateMobileDevicePrestage.go
+++ b/examples/mobile_device_prestages/CreateMobileDevicePrestage/CreateMobileDevicePrestage.go
@@ -51,7 +51,7 @@ func main() {
 		UseStorageQuotaSize:                    jamfpro.FalsePtr(),
 		TemporarySessionOnly:                   jamfpro.FalsePtr(),
 		EnforceTemporarySessionTimeout:         jamfpro.FalsePtr(),
-		TemporarySessionTimeout:                0,
+		TemporarySessionTimeout:                nil,
 		EnforceUserSessionTimeout:              jamfpro.FalsePtr(),
 		UserSessionTimeout:                     nil,
 		SiteId:                                 "-1",

--- a/examples/mobile_device_prestages/UpdateMobileDevicePrestageByID/UpdateMobileDevicePrestageByID.go
+++ b/examples/mobile_device_prestages/UpdateMobileDevicePrestageByID/UpdateMobileDevicePrestageByID.go
@@ -59,7 +59,7 @@ func main() {
 		UseStorageQuotaSize:                    jamfpro.FalsePtr(),
 		TemporarySessionOnly:                   jamfpro.FalsePtr(),
 		EnforceTemporarySessionTimeout:         jamfpro.FalsePtr(),
-		TemporarySessionTimeout:                0,
+		TemporarySessionTimeout:                nil,
 		EnforceUserSessionTimeout:              jamfpro.FalsePtr(),
 		UserSessionTimeout:                     nil,
 		SiteId:                                 "-1",

--- a/examples/mobile_device_prestages/UpdateMobileDevicePrestageByName/UpdateMobileDevicePrestageByName.go
+++ b/examples/mobile_device_prestages/UpdateMobileDevicePrestageByName/UpdateMobileDevicePrestageByName.go
@@ -59,7 +59,7 @@ func main() {
 		UseStorageQuotaSize:                    jamfpro.FalsePtr(),
 		TemporarySessionOnly:                   jamfpro.FalsePtr(),
 		EnforceTemporarySessionTimeout:         jamfpro.FalsePtr(),
-		TemporarySessionTimeout:                0,
+		TemporarySessionTimeout:                nil,
 		EnforceUserSessionTimeout:              jamfpro.FalsePtr(),
 		UserSessionTimeout:                     nil,
 		SiteId:                                 "-1",

--- a/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
+++ b/sdk/jamfpro/jamfproapi_mobile_device_prestages.go
@@ -61,13 +61,13 @@ type ResourceMobileDevicePrestage struct {
 	PreventActivationLock                  *bool                                           `json:"preventActivationLock"`
 	EnableDeviceBasedActivationLock        *bool                                           `json:"enableDeviceBasedActivationLock"`
 	DeviceEnrollmentProgramInstanceID      string                                          `json:"deviceEnrollmentProgramInstanceId"`
-	SkipSetupItems                         MobileDevicePrestageSubsetSkipSetupItems        `json:"skipSetupItems"`
+	SkipSetupItems                         MobileDevicePrestageSubsetSkipSetupItems        `json:"skipSetupItems,omitempty"`
 	LocationInformation                    MobileDevicePrestageSubsetLocationInformation   `json:"locationInformation"`
 	PurchasingInformation                  MobileDevicePrestageSubsetPurchasingInformation `json:"purchasingInformation"`
-	AnchorCertificates                     []string                                        `json:"anchorCertificates"`
-	EnrollmentCustomizationID              string                                          `json:"enrollmentCustomizationId"`
-	Language                               string                                          `json:"language"`
-	Region                                 string                                          `json:"region"`
+	AnchorCertificates                     []string                                        `json:"anchorCertificates,omitempty"`
+	EnrollmentCustomizationID              string                                          `json:"enrollmentCustomizationId,omitempty"`
+	Language                               string                                          `json:"language,omitempty"`
+	Region                                 string                                          `json:"region,omitempty"`
 	AutoAdvanceSetup                       *bool                                           `json:"autoAdvanceSetup"`
 	AllowPairing                           *bool                                           `json:"allowPairing"`
 	MultiUser                              *bool                                           `json:"multiUser"`
@@ -81,17 +81,17 @@ type ResourceMobileDevicePrestage struct {
 	UseStorageQuotaSize                    *bool                                           `json:"useStorageQuotaSize"`
 	TemporarySessionOnly                   *bool                                           `json:"temporarySessionOnly"`
 	EnforceTemporarySessionTimeout         *bool                                           `json:"enforceTemporarySessionTimeout"`
-	TemporarySessionTimeout                int                                             `json:"temporarySessionTimeout"`
+	TemporarySessionTimeout                *int                                            `json:"temporarySessionTimeout,omitempty"`
 	EnforceUserSessionTimeout              *bool                                           `json:"enforceUserSessionTimeout"`
-	UserSessionTimeout                     *int                                            `json:"userSessionTimeout"`
+	UserSessionTimeout                     *int                                            `json:"userSessionTimeout,omitempty"`
 	ID                                     string                                          `json:"id"`
-	ProfileUuid                            string                                          `json:"profileUuid"`
-	SiteId                                 string                                          `json:"siteId"`
+	ProfileUuid                            string                                          `json:"profileUuid,omitempty"`
+	SiteId                                 string                                          `json:"siteId,omitempty"`
 	VersionLock                            int                                             `json:"versionLock"`
-	PrestageMinimumOsTargetVersionTypeIos  string                                          `json:"prestageMinimumOsTargetVersionTypeIos"`
-	MinimumOsSpecificVersionIos            string                                          `json:"minimumOsSpecificVersionIos"`
-	PrestageMinimumOsTargetVersionTypeIpad string                                          `json:"prestageMinimumOsTargetVersionTypeIpad"`
-	MinimumOsSpecificVersionIpad           string                                          `json:"minimumOsSpecificVersionIpad"`
+	PrestageMinimumOsTargetVersionTypeIos  string                                          `json:"prestageMinimumOsTargetVersionTypeIos,omitempty"`
+	MinimumOsSpecificVersionIos            string                                          `json:"minimumOsSpecificVersionIos,omitempty"`
+	PrestageMinimumOsTargetVersionTypeIpad string                                          `json:"prestageMinimumOsTargetVersionTypeIpad,omitempty"`
+	MinimumOsSpecificVersionIpad           string                                          `json:"minimumOsSpecificVersionIpad,omitempty"`
 	RTSConfigProfileId                     *string                                         `json:"rtsConfigProfileId"`
 }
 

--- a/sdk/jamfpro/shared_helpers.go
+++ b/sdk/jamfpro/shared_helpers.go
@@ -33,6 +33,11 @@ func IntPtr(i int) *int {
 	return &i
 }
 
+// StringPtr returns a pointer to a string value
+func StringPtr(s string) *string {
+	return &s
+}
+
 // IncrementStringID increments the given ID string.
 // It returns the incremented ID as a string or panics if the input is not convertible to an integer.
 func IncrementStringID(currentID string) string {


### PR DESCRIPTION
# Change

* Add StringPtr shared helper funtion to handle null string values where necessary
* Add `onitempty` tag options for some mobile_device_prestage fields
* Specify `TemporarySessionTimeout` as Ptr so it can accept null value
* Update example scripts

Note that a new resource/data source for the provider has been compiled locally against this version of the SDK and has tested successfully.

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
