### PR TITLE
feat: add support for device-enrollments/public-key retrieval

### DIFF
--- a/examples/device_enrollments/GetDeviceEnrollmentsPublicKey/GetDeviceEnrollmentsPublicKey.go
+++ b/examples/device_enrollments/GetDeviceEnrollmentsPublicKey/GetDeviceEnrollmentsPublicKey.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	// Initialize the Jamf Pro client with the HTTP client configuration
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	// Call the GetDeviceEnrollmentsPublicKey method to retrieve the public key
+	response, err := client.GetDeviceEnrollmentsPublicKey()
+	if err != nil {
+		log.Fatalf("Failed to retrieve Public Key: %v", err)
+	}
+	fmt.Print(response)
+}

--- a/sdk/jamfpro/jamfproapi_device_enrollments.go
+++ b/sdk/jamfpro/jamfproapi_device_enrollments.go
@@ -175,6 +175,23 @@ func (c *Client) GetDeviceEnrollmentSyncStates(id string) ([]ResourceDeviceEnrol
 	return out, nil
 }
 
+// GetDeviceEnrollmentsPublicKey retrieves the public key for device enrollments
+func (c *Client) GetDeviceEnrollmentsPublicKey() (string, error) {
+	endpoint := fmt.Sprintf("%s/public-key", uriDeviceEnrollments)
+
+	var out []byte
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &out)
+	if err != nil {
+		return "", fmt.Errorf(errMsgFailedGet, "device enrollment public key", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return string(out), nil
+}
+
 // CreateDeviceEnrollmentWithMDMServerToken creates a new device enrollment instance using
 // The downloaded token base 64 encoded from the MDM server to be used to create a new Device Enrollment Instance.
 func (c *Client) CreateDeviceEnrollmentWithMDMServerToken(tokenUpload *ResourceDeviceEnrollmentTokenUpload) (*ResponseDeviceEnrollmentTokenUpload, error) {


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Adds support for returning the device enrollment public key (PEM encoded cert) as a string. Means tooling using the Go SDK can convert this to a file for users so they can provide it to Apple Business/School Manager to generate their MDM Server Token. 

This API endpoint only returns the content type `application/x-pem-file` so we need to convert it to a string with no structure. The idea is that the Terraform provider will be able to return that string as a data source output, which a front end app can convert to a file for users to download.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
