### PR TITLE
fix: HTTP request/response handling in SyncJamfProtectPlans

### DIFF
--- a/sdk/jamfpro/jamfproapi_jamf_protect.go
+++ b/sdk/jamfpro/jamfproapi_jamf_protect.go
@@ -225,19 +225,17 @@ func (c *Client) GetJamfProtectPlans(params url.Values) (*ResponseJamfProtectPla
 func (c *Client) SyncJamfProtectPlans() error {
 	endpoint := fmt.Sprintf("%s/plans/sync", uriJamfProtect)
 
-	var errorResponse SharedResourcResponseError
-	resp, err := c.HTTP.DoRequest("POST", endpoint, nil, &errorResponse)
-	if err != nil {
-		return fmt.Errorf(errMsgFailedUpdate, "sync Jamf Protect plans", err)
+	resp, _ := c.HTTP.DoRequest("POST", endpoint, nil, nil)
+	if resp == nil {
+		return fmt.Errorf("failed to sync Jamf Protect plans: no response received")
 	}
 
-	if resp != nil && resp.Body != nil {
+	if resp.Body != nil {
 		defer resp.Body.Close()
 	}
 
-	// Check if the response contains errors
-	if errorResponse.HTTPStatus != 0 {
-		return fmt.Errorf("failed to sync Jamf Protect plans: HTTP %d - %+v", errorResponse.HTTPStatus, errorResponse.Errors)
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("failed to sync Jamf Protect plans: unexpected status code %d", resp.StatusCode)
 	}
 
 	return nil


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

The `/v1/jamf-protect/plans/sync` endpoint is a bit different from others.

* It accepts an empty POST
* It returns a response code and header but no body.

This change removes any checking of the response body in the function and instead we make sure we receive a 204 response code, indicating success. Any other response codes indicates a failure. Function works as expected now for doing a one-off Jamf Protect Plan sync.

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
