### PR TITLE
fix: update computer inventory settings to use v2 endpoint

### DIFF
--- a/examples/computer_inventory_settings/CreateComputerInventoryCollectionSettingsCustomPath/CreateComputerInventoryCollectionSettingsCustomPath.go
+++ b/examples/computer_inventory_settings/CreateComputerInventoryCollectionSettingsCustomPath/CreateComputerInventoryCollectionSettingsCustomPath.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	// Define the path to the JSON configuration file
-	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
 
 	// Initialize the Jamf Pro client with the HTTP client configuration
 	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)

--- a/examples/computer_inventory_settings/DeleteComputerInventoryCollectionSettingsCustomPathByID/DeleteComputerInventoryCollectionSettingsCustomPathByID.go
+++ b/examples/computer_inventory_settings/DeleteComputerInventoryCollectionSettingsCustomPathByID/DeleteComputerInventoryCollectionSettingsCustomPathByID.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	// Define the path to the JSON configuration file
-	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
 
 	// Initialize the Jamf Pro client with the HTTP client configuration
 	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
@@ -19,7 +19,7 @@ func main() {
 
 	// ID of the custom path to delete.
 	// Replace "123" with the actual ID of the custom path you want to delete.
-	id := "3"
+	id := "5"
 
 	// Call the delete function.
 	err = client.DeleteComputerInventoryCollectionSettingsCustomPathByID(id)

--- a/examples/computer_inventory_settings/GetComputerInventoryCollectionSettings/GetComputerInventoryCollectionSettings.go
+++ b/examples/computer_inventory_settings/GetComputerInventoryCollectionSettings/GetComputerInventoryCollectionSettings.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Define the path to the JSON configuration file
-	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
 
 	// Initialize the Jamf Pro client with the HTTP client configuration
 	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)

--- a/examples/computer_inventory_settings/UpdateComputerInventoryCollectionSettings/UpdateComputerInventoryCollectionSettings.go
+++ b/examples/computer_inventory_settings/UpdateComputerInventoryCollectionSettings/UpdateComputerInventoryCollectionSettings.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Define the path to the JSON configuration file
-	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
 
 	// Initialize the Jamf Pro client with the HTTP client configuration
 	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
@@ -18,78 +18,47 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
-	// Define the new settings
+	// Define the new settings (match current SDK: preferences type and applicationPaths only)
+	// Build the settings payload: only include preferences in the PATCH.
+	// Do NOT include applicationPaths with arbitrary IDs — the API will return INVALID_ID if
+	// the ID(s) do not already exist. To add custom paths use the dedicated custom-path endpoint.
 	newSettings := &jamfpro.ResourceComputerInventoryCollectionSettings{
-		ComputerInventoryCollectionPreferences: struct {
-			MonitorApplicationUsage                      bool `json:"monitorApplicationUsage"`
-			IncludeFonts                                 bool `json:"includeFonts"`
-			IncludePlugins                               bool `json:"includePlugins"`
-			IncludePackages                              bool `json:"includePackages"`
-			IncludeSoftwareUpdates                       bool `json:"includeSoftwareUpdates"`
-			IncludeSoftwareId                            bool `json:"includeSoftwareId"`
-			IncludeAccounts                              bool `json:"includeAccounts"`
-			CalculateSizes                               bool `json:"calculateSizes"`
-			IncludeHiddenAccounts                        bool `json:"includeHiddenAccounts"`
-			IncludePrinters                              bool `json:"includePrinters"`
-			IncludeServices                              bool `json:"includeServices"`
-			CollectSyncedMobileDeviceInfo                bool `json:"collectSyncedMobileDeviceInfo"`
-			UpdateLdapInfoOnComputerInventorySubmissions bool `json:"updateLdapInfoOnComputerInventorySubmissions"`
-			MonitorBeacons                               bool `json:"monitorBeacons"`
-			AllowChangingUserAndLocation                 bool `json:"allowChangingUserAndLocation"`
-			UseUnixUserPaths                             bool `json:"useUnixUserPaths"`
-			CollectUnmanagedCertificates                 bool `json:"collectUnmanagedCertificates"`
-		}{
-			MonitorApplicationUsage:       false,
-			IncludeFonts:                  false,
-			IncludePlugins:                false,
-			IncludePackages:               true,
-			IncludeSoftwareUpdates:        false,
-			IncludeSoftwareId:             true,
-			IncludeAccounts:               true,
-			CalculateSizes:                false,
-			IncludeHiddenAccounts:         false,
-			IncludePrinters:               true,
-			IncludeServices:               true,
-			CollectSyncedMobileDeviceInfo: false,
+		ComputerInventoryCollectionPreferences: jamfpro.ComputerInventoryCollectionSettingsSubsetPreferences{
+			MonitorApplicationUsage:                      false,
+			IncludePackages:                              true,
+			IncludeSoftwareUpdates:                       false,
+			IncludeSoftwareId:                            true,
+			IncludeAccounts:                              true,
+			CalculateSizes:                               false,
+			IncludeHiddenAccounts:                        false,
+			IncludePrinters:                              true,
+			IncludeServices:                              true,
+			CollectSyncedMobileDeviceInfo:                false,
 			UpdateLdapInfoOnComputerInventorySubmissions: false,
-			MonitorBeacons:               false,
-			AllowChangingUserAndLocation: true,
-			UseUnixUserPaths:             true,
-			CollectUnmanagedCertificates: true,
-		},
-		ApplicationPaths: []jamfpro.ComputerInventoryCollectionSettingsSubsetPathItem{
-			{
-				ID:   "1",
-				Path: "/Example/Path/To/App/",
-			},
-		},
-		FontPaths: []jamfpro.ComputerInventoryCollectionSettingsSubsetPathItem{
-			{
-				ID:   "2",
-				Path: "/Example/Path/To/Font/",
-			},
-		},
-		PluginPaths: []jamfpro.ComputerInventoryCollectionSettingsSubsetPathItem{
-			{
-				ID:   "3",
-				Path: "/Example/Path/To/Plugin/",
-			},
+			MonitorBeacons:                               false,
+			AllowChangingUserAndLocation:                 true,
+			UseUnixUserPaths:                             true,
+			CollectUnmanagedCertificates:                 true,
 		},
 	}
 
-	// Update computer inventory collection settings
-	updatedSettings, err := client.UpdateComputerInventoryCollectionSettings(newSettings)
+	// Update computer inventory collection settings (API returns 204 No Content on success)
+	_, err = client.UpdateComputerInventoryCollectionSettings(newSettings)
 	if err != nil {
 		log.Fatalf("Error updating Computer Inventory Collection Settings: %s", err)
 	}
 
-	// Convert the updated settings to pretty-printed JSON
-	updatedSettingsJSON, err := json.MarshalIndent(updatedSettings, "", "    ")
-	if err != nil {
-		log.Fatalf("Error marshalling updated Computer Inventory Collection Settings to JSON: %s", err)
+	// Example: add a custom application path using the custom-path endpoint
+	// (Do this after the PATCH; creating custom paths is a separate API call.)
+	newPath := &jamfpro.ResourceComputerInventoryCollectionSettingsCustomPath{
+		Scope: "APP",
+		Path:  "/Example/Path/To/App4/",
 	}
-
-	// Print the pretty-printed JSON of the updated settings
-	fmt.Println("Updated Computer Inventory Collection Settings:")
-	fmt.Println(string(updatedSettingsJSON))
+	created, err := client.CreateComputerInventoryCollectionSettingsCustomPath(newPath)
+	if err != nil {
+		log.Fatalf("Error creating custom application path: %s", err)
+	}
+	createdJSON, _ := json.MarshalIndent(created, "", "    ")
+	fmt.Println("Created custom application path:")
+	fmt.Println(string(createdJSON))
 }


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

This is a breaking change because it removes support for Fonts and Plugins in computer inventory collection settings (they are removed from the new V2 endpoint and deprecated)

V1 is deprecated, has been for a while and. Was hitting an error when updating with the provider against the old V1 endpoint in 11.21 which prompted me to investigate.

Have fully tested and updated the example scripts.

UpdateComputerInventoryCollectionSettings set up to handle an empty response body - as we only get a 204 when we PATCH to the endpoint.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
