### PR TITLE
feat: add OSShowcase field to ComputerPrestageSubsetSkipSetupItems (Jamf Pro 11.21)

### DIFF
--- a/sdk/jamfpro/jamfproapi_computer_prestages.go
+++ b/sdk/jamfpro/jamfproapi_computer_prestages.go
@@ -136,6 +136,7 @@ type ComputerPrestageSubsetSkipSetupItems struct {
 	Wallpaper                 *bool `json:"Wallpaper"`
 	SoftwareUpdate            *bool `json:"SoftwareUpdate"`
 	AdditionalPrivacySettings *bool `json:"AdditionalPrivacySettings"`
+	OSShowcase                *bool `json:"OSShowcase"`
 }
 
 type ComputerPrestageSubsetLocationInformation struct {


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

New Skip Setup Item for Computer PreStages. Introduced in Jamf Pro 11.21.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
