### PR TITLE
fix: make criteria field optional in ResourceSmartMobileDeviceGroupV1

### DIFF
--- a/sdk/jamfpro/jamfproapi_smart_mobile_device_groups.go
+++ b/sdk/jamfpro/jamfproapi_smart_mobile_device_groups.go
@@ -23,7 +23,7 @@ import (
 type ResourceSmartMobileDeviceGroupV1 struct {
 	GroupName        string                           `json:"groupName"`
 	GroupDescription string                           `json:"groupDescription,omitempty"`
-	Criteria         []SharedSubsetCriteriaJamfProAPI `json:"criteria"`
+	Criteria         []SharedSubsetCriteriaJamfProAPI `json:"criteria,omitempty"`
 	SiteId           *string                          `json:"siteId,omitempty"`
 }
 


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Jamf Pro allows smart groups containing all devices/computers by creating without any criteria. If sending [] for criteria, the API generates a 500 error. If the field is omitted, then a group can be created successfully.

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
