### PR TITLE
feat: Add Get Computer Inventory by Serial Number function and return additional inventory data

### DIFF
--- a/examples/computer_inventory/GetComputerInventoryBySerialNumber/GetComputerInventoryBySerialNumber.go
+++ b/examples/computer_inventory/GetComputerInventoryBySerialNumber/GetComputerInventoryBySerialNumber.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+
+	// Initialize the Jamf Pro client with the HTTP client configuration
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	// Define the serial number of the computer inventory you want to retrieve
+	serialNumber := "C02ABC123DEF"
+
+	// Call the GetComputerInventoryBySerialNumber function
+	computerInventory, err := client.GetComputerInventoryBySerialNumber(serialNumber)
+	if err != nil {
+		log.Fatalf("Error fetching computer inventory by serial number: %v", err)
+	}
+
+	// Pretty print the response
+	prettyJSON, err := json.MarshalIndent(computerInventory, "", "    ")
+	if err != nil {
+		log.Fatalf("Failed to generate pretty JSON: %v", err)
+	}
+	fmt.Printf("%s\n", prettyJSON)
+}

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -107,7 +107,7 @@ type ComputerInventorySubsetGeneralRemoteManagement struct {
 type ComputerInventorySubsetGeneralMdmCapable struct {
 	Capable            bool     `json:"capable"`
 	CapableUsers       []string `json:"capableUsers"`
-	UserManagementInfo [][]struct {
+	UserManagementInfo []struct {
 		CapableUser  string `json:"capableUser"`
 		ManagementId string `json:"managementId"`
 	} `json:"userManagementInfo"`

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -628,6 +628,23 @@ func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInven
 	return nil, fmt.Errorf(errMsgFailedGetByName, "computer inventory", name, err)
 }
 
+// GetComputerInventoryBySerialNumber retrieves a specific computer's inventory information by its serial number.
+func (c *Client) GetComputerInventoryBySerialNumber(serialNumber string) (*ResourceComputerInventory, error) {
+	params := url.Values{}
+	params.Set("filter", fmt.Sprintf("hardware.serialNumber==\"%s\"", serialNumber))
+
+	inventories, err := c.GetComputersInventory(params)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer inventory", err)
+	}
+
+	if len(inventories.Results) == 0 {
+		return nil, fmt.Errorf("failed to find computer inventory by serial number '%s'", serialNumber)
+	}
+
+	return &inventories.Results[0], nil
+}
+
 // UpdateComputerInventoryByID updates a specific computer's inventory information by its ID.
 func (c *Client) UpdateComputerInventoryByID(id string, inventoryUpdate *ResourceComputerInventory) (*ResourceComputerInventory, error) {
 	endpoint := fmt.Sprintf("%s/%s", uriComputersInventory, id)

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -598,9 +598,26 @@ func (c *Client) GetComputersInventory(params url.Values) (*ResponseComputerInve
 func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory, error) {
 	endpoint := fmt.Sprintf("%s/%s", uriComputersInventory, id)
 
+	// Add all section parameters to get complete inventory data
+	sections := []string{
+		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
+		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
+		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
+		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
+		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
+		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
+	}
+
+	params := url.Values{}
+	for _, section := range sections {
+		params.Add("section", section)
+	}
+
+	endpointWithParams := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+
 	// Fetch the computer inventory by ID
 	var responseInventory ResourceComputerInventory
-	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &responseInventory)
+	resp, err := c.HTTP.DoRequest("GET", endpointWithParams, nil, &responseInventory)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGetByID, "computer inventory", id, err)
 	}
@@ -614,7 +631,22 @@ func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory
 
 // GetComputerInventoryByName retrieves a specific computer's inventory information by its name.
 func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInventory, error) {
-	inventories, err := c.GetComputersInventory(nil)
+	// Add all section parameters to get complete inventory data
+	sections := []string{
+		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
+		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
+		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
+		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
+		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
+		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
+	}
+
+	params := url.Values{}
+	for _, section := range sections {
+		params.Add("section", section)
+	}
+
+	inventories, err := c.GetComputersInventory(params)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedPaginatedGet, "computer inventory", err)
 	}
@@ -630,8 +662,21 @@ func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInven
 
 // GetComputerInventoryBySerialNumber retrieves a specific computer's inventory information by its serial number.
 func (c *Client) GetComputerInventoryBySerialNumber(serialNumber string) (*ResourceComputerInventory, error) {
+	// Add filter and all section parameters to get complete inventory data
+	sections := []string{
+		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
+		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
+		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
+		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
+		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
+		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
+	}
+
 	params := url.Values{}
 	params.Set("filter", fmt.Sprintf("hardware.serialNumber==\"%s\"", serialNumber))
+	for _, section := range sections {
+		params.Add("section", section)
+	}
 
 	inventories, err := c.GetComputersInventory(params)
 	if err != nil {

--- a/sdk/jamfpro/jamfproapi_computer_inventory.go
+++ b/sdk/jamfpro/jamfproapi_computer_inventory.go
@@ -20,6 +20,16 @@ import (
 
 const uriComputersInventory = "/api/v1/computers-inventory"
 
+// computerInventorySections contains all available sections for computer inventory API requests
+var computerInventorySections = []string{
+	"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
+	"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
+	"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
+	"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
+	"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
+	"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
+}
+
 // List
 
 // ResponseComputerInventoryList represents the top-level JSON response structure.
@@ -599,17 +609,8 @@ func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory
 	endpoint := fmt.Sprintf("%s/%s", uriComputersInventory, id)
 
 	// Add all section parameters to get complete inventory data
-	sections := []string{
-		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
-		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
-		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
-		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
-		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
-		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
-	}
-
 	params := url.Values{}
-	for _, section := range sections {
+	for _, section := range computerInventorySections {
 		params.Add("section", section)
 	}
 
@@ -632,17 +633,8 @@ func (c *Client) GetComputerInventoryByID(id string) (*ResourceComputerInventory
 // GetComputerInventoryByName retrieves a specific computer's inventory information by its name.
 func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInventory, error) {
 	// Add all section parameters to get complete inventory data
-	sections := []string{
-		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
-		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
-		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
-		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
-		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
-		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
-	}
-
 	params := url.Values{}
-	for _, section := range sections {
+	for _, section := range computerInventorySections {
 		params.Add("section", section)
 	}
 
@@ -663,18 +655,9 @@ func (c *Client) GetComputerInventoryByName(name string) (*ResourceComputerInven
 // GetComputerInventoryBySerialNumber retrieves a specific computer's inventory information by its serial number.
 func (c *Client) GetComputerInventoryBySerialNumber(serialNumber string) (*ResourceComputerInventory, error) {
 	// Add filter and all section parameters to get complete inventory data
-	sections := []string{
-		"GENERAL", "DISK_ENCRYPTION", "PURCHASING", "APPLICATIONS", "STORAGE",
-		"USER_AND_LOCATION", "CONFIGURATION_PROFILES", "PRINTERS", "SERVICES",
-		"HARDWARE", "LOCAL_USER_ACCOUNTS", "CERTIFICATES", "ATTACHMENTS",
-		"PLUGINS", "PACKAGE_RECEIPTS", "FONTS", "SECURITY", "OPERATING_SYSTEM",
-		"LICENSED_SOFTWARE", "IBEACONS", "SOFTWARE_UPDATES", "EXTENSION_ATTRIBUTES",
-		"CONTENT_CACHING", "GROUP_MEMBERSHIPS",
-	}
-
 	params := url.Values{}
 	params.Set("filter", fmt.Sprintf("hardware.serialNumber==\"%s\"", serialNumber))
-	for _, section := range sections {
+	for _, section := range computerInventorySections {
 		params.Add("section", section)
 	}
 


### PR DESCRIPTION
# Change

- Added `GetComputerInventoryBySerialNumber()` function for serial number lookups
- Fixed `UserManagementInfo` struct type to prevent unmarshaling errors
- Updated Get functions to request all inventory sections for complete data using shared `computerInventorySections` variable

## Motivation
Serial number lookups are a common workflow requirement but weren't supported. Additionally, the existing Get functions only retrieved the GENERAL section by default, returning incomplete inventory data.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
