### PR TITLE
fix: update ResourceMobileDeviceGroup fields to use pointers for better handling of optional values

### DIFF
--- a/examples/mobile_device_enrollment_groups/CreateMobileDeviceGroupSmart/CreateMobileDeviceGroupSmart.go
+++ b/examples/mobile_device_enrollment_groups/CreateMobileDeviceGroupSmart/CreateMobileDeviceGroupSmart.go
@@ -21,7 +21,7 @@ func main() {
 	newGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Sample Smart Group",
 		IsSmart: true,
-		Criteria: jamfpro.SharedContainerCriteria{
+		Criteria: &jamfpro.SharedContainerCriteria{
 			Size: 3, // The number of criteria
 			Criterion: []jamfpro.SharedSubsetCriteria{
 				{
@@ -51,7 +51,7 @@ func main() {
 				},
 			},
 		},
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},

--- a/examples/mobile_device_enrollment_groups/CreateMobileDeviceGroupStatic/CreateMobileDeviceGroupStatic.go
+++ b/examples/mobile_device_enrollment_groups/CreateMobileDeviceGroupStatic/CreateMobileDeviceGroupStatic.go
@@ -22,11 +22,11 @@ func main() {
 	newGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Static Group",
 		IsSmart: false,
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},
-		MobileDevices: []jamfpro.MobileDeviceGroupSubsetDeviceItem{
+		MobileDevices: &[]jamfpro.MobileDeviceGroupSubsetDeviceItem{
 			{
 				ID:             38,
 				Name:           "Test Device",

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDSmart/UpdateMobileDeviceGroupByIDSmart.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDSmart/UpdateMobileDeviceGroupByIDSmart.go
@@ -25,7 +25,7 @@ func main() {
 	updatedSmartGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Sample Smart Group",
 		IsSmart: true,
-		Criteria: jamfpro.SharedContainerCriteria{
+		Criteria: &jamfpro.SharedContainerCriteria{
 			Size: 3, // The number of criteria
 			Criterion: []jamfpro.SharedSubsetCriteria{
 				{
@@ -55,7 +55,7 @@ func main() {
 				},
 			},
 		},
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStatic/UpdateMobileDeviceGroupByIDStatic.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStatic/UpdateMobileDeviceGroupByIDStatic.go
@@ -25,11 +25,11 @@ func main() {
 	updatedStaticGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Static Group",
 		IsSmart: false,
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},
-		MobileDevices: []jamfpro.MobileDeviceGroupSubsetDeviceItem{
+		MobileDevices: &[]jamfpro.MobileDeviceGroupSubsetDeviceItem{
 			{
 				ID:             38,
 				Name:           "Test Device",

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStaticGroupAdditions/UpdateMobileDeviceGroupByIDStaticGroupAdditions.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStaticGroupAdditions/UpdateMobileDeviceGroupByIDStaticGroupAdditions.go
@@ -23,7 +23,7 @@ func main() {
 
 	// Define the updated group data with mobile device additions
 	updatedGroup := &jamfpro.ResourceMobileDeviceGroup{
-		MobileDeviceAdditions: []jamfpro.MobileDeviceGroupSubsetDeviceItem{
+		MobileDeviceAdditions: &[]jamfpro.MobileDeviceGroupSubsetDeviceItem{
 			{
 				ID:             38,
 				Name:           "Test Device",

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStaticGroupDeletions/UpdateMobileDeviceGroupByIDStaticGroupDeletions.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByIDStaticGroupDeletions/UpdateMobileDeviceGroupByIDStaticGroupDeletions.go
@@ -23,7 +23,7 @@ func main() {
 
 	// Define the updated group data with mobile device deletions
 	updatedGroup := &jamfpro.ResourceMobileDeviceGroup{
-		MobileDeviceDeletions: []jamfpro.MobileDeviceGroupSubsetDeviceItem{
+		MobileDeviceDeletions: &[]jamfpro.MobileDeviceGroupSubsetDeviceItem{
 			{
 				ID:             38,
 				Name:           "Test Device",

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByNameSmart/UpdateMobileDeviceGroupByNameSmart.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByNameSmart/UpdateMobileDeviceGroupByNameSmart.go
@@ -25,7 +25,7 @@ func main() {
 	updatedSmartGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Sample Smart Group",
 		IsSmart: true,
-		Criteria: jamfpro.SharedContainerCriteria{
+		Criteria: &jamfpro.SharedContainerCriteria{
 			Size: 3, // The number of criteria
 			Criterion: []jamfpro.SharedSubsetCriteria{
 				{
@@ -55,7 +55,7 @@ func main() {
 				},
 			},
 		},
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},

--- a/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByNameStatic/UpdateMobileDeviceGroupByNameStatic.go
+++ b/examples/mobile_device_enrollment_groups/UpdateMobileDeviceGroupByNameStatic/UpdateMobileDeviceGroupByNameStatic.go
@@ -25,11 +25,11 @@ func main() {
 	updatedStaticGroup := &jamfpro.ResourceMobileDeviceGroup{
 		Name:    "Static Group",
 		IsSmart: false,
-		Site: jamfpro.SharedResourceSite{
+		Site: &jamfpro.SharedResourceSite{
 			ID:   -1,
 			Name: "None",
 		},
-		MobileDevices: []jamfpro.MobileDeviceGroupSubsetDeviceItem{
+		MobileDevices: &[]jamfpro.MobileDeviceGroupSubsetDeviceItem{
 			{
 				ID:             38,
 				Name:           "Test Device",

--- a/sdk/jamfpro/classicapi_mobile_device_groups.go
+++ b/sdk/jamfpro/classicapi_mobile_device_groups.go
@@ -36,14 +36,14 @@ type MobileDeviceGroupsListItem struct {
 
 // ResourceMobileDeviceGroup represents the response for a single mobile device group.
 type ResourceMobileDeviceGroup struct {
-	ID                    int                                 `xml:"id"`
-	Name                  string                              `xml:"name"`
-	IsSmart               bool                                `xml:"is_smart"`
-	Criteria              SharedContainerCriteria             `xml:"criteria,omitempty"`
-	Site                  SharedResourceSite                  `xml:"site"`
-	MobileDevices         []MobileDeviceGroupSubsetDeviceItem `xml:"mobile_devices>mobile_device,omitempty"`
-	MobileDeviceAdditions []MobileDeviceGroupSubsetDeviceItem `xml:"mobile_device_additions>mobile_device,omitempty"`
-	MobileDeviceDeletions []MobileDeviceGroupSubsetDeviceItem `xml:"mobile_device_deletions>mobile_device,omitempty"`
+	ID                    int                                  `xml:"id"`
+	Name                  string                               `xml:"name"`
+	IsSmart               bool                                 `xml:"is_smart"`
+	Criteria              *SharedContainerCriteria             `xml:"criteria,omitempty"`
+	Site                  *SharedResourceSite                  `xml:"site"`
+	MobileDevices         *[]MobileDeviceGroupSubsetDeviceItem `xml:"mobile_devices>mobile_device,omitempty"`
+	MobileDeviceAdditions *[]MobileDeviceGroupSubsetDeviceItem `xml:"mobile_device_additions>mobile_device,omitempty"`
+	MobileDeviceDeletions *[]MobileDeviceGroupSubsetDeviceItem `xml:"mobile_device_deletions>mobile_device,omitempty"`
 }
 
 // MobileDeviceGroupDeviceItem represents a single mobile device within a group.


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Brings this in line with how computer groups are handled in the SDK with the Classic API. Main advantage is for static groups, ptr usage allows us to omit the mobile_devices field so group member devices are not removed unintentionally. Will follow up with provider update shortly.

I also changed the other nested fields in ResourceMobileDeviceGroup use ptrs for consistency with how computer groups are implemented in the SDK.

## Type of Change

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
