### PR TITLE
feat: add AD CS settings support and examples

### DIFF
--- a/examples/adcs_settings/CreateAdcsSettingsV1/CreateAdcsSettingsV1.go
+++ b/examples/adcs_settings/CreateAdcsSettingsV1/CreateAdcsSettingsV1.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	revocationEnabled := true
+	outbound := true
+
+	request := &jamfpro.ResourceAdcsSettingsV1{
+		DisplayName:       "Example AD CS Settings",
+		CAName:            "EXAMPLE-SUBCA02-CA",
+		FQDN:              "example-subca02.example.com",
+		RevocationEnabled: &revocationEnabled,
+		APIClientID:       "c1bcec08-5f34-40fa-af52-9d3413ac916d",
+		Outbound:          &outbound,
+	}
+
+	created, err := client.CreateAdcsSettingsV1(request)
+	if err != nil {
+		log.Fatalf("Error creating AD CS settings: %v", err)
+	}
+
+	output, err := json.MarshalIndent(created, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling creation response: %v", err)
+	}
+
+	fmt.Printf("Created AD CS settings: %s\n", string(output))
+}

--- a/examples/adcs_settings/DeleteAdcsSettingsByIDV1/DeleteAdcsSettingsByIDV1.go
+++ b/examples/adcs_settings/DeleteAdcsSettingsByIDV1/DeleteAdcsSettingsByIDV1.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	adcsSettingsID := "4"
+
+	if err := client.DeleteAdcsSettingsByIDV1(adcsSettingsID); err != nil {
+		log.Fatalf("Error deleting AD CS settings %s: %v", adcsSettingsID, err)
+	}
+
+	log.Printf("Successfully deleted AD CS settings %s", adcsSettingsID)
+}

--- a/examples/adcs_settings/GetAdcsSettingsByIDV1/GetAdcsSettingsByIDV1.go
+++ b/examples/adcs_settings/GetAdcsSettingsByIDV1/GetAdcsSettingsByIDV1.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	adcsSettingsID := "4"
+
+	settings, err := client.GetAdcsSettingsByIDV1(adcsSettingsID)
+	if err != nil {
+		log.Fatalf("Error fetching AD CS settings %s: %v", adcsSettingsID, err)
+	}
+
+	output, err := json.MarshalIndent(settings, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling AD CS settings: %v", err)
+	}
+
+	fmt.Printf("AD CS settings %s: %s\n", adcsSettingsID, string(output))
+}

--- a/examples/adcs_settings/UpdateAdcsSettingsByIDV1/UpdateAdcsSettingsByIDV1.go
+++ b/examples/adcs_settings/UpdateAdcsSettingsByIDV1/UpdateAdcsSettingsByIDV1.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	adcsSettingsID := "4"
+	revocationEnabled := false
+
+	updatePayload := &jamfpro.ResourceAdcsSettingsV1{
+		DisplayName:       "Example AD CS Settings (Updated)",
+		RevocationEnabled: &revocationEnabled,
+	}
+
+	if err := client.UpdateAdcsSettingsByIDV1(adcsSettingsID, updatePayload); err != nil {
+		log.Fatalf("Error updating AD CS settings %s: %v", adcsSettingsID, err)
+	}
+
+	log.Printf("Successfully updated AD CS settings %s", adcsSettingsID)
+}

--- a/sdk/jamfpro/jamfproapi_adcs_settings.go
+++ b/sdk/jamfpro/jamfproapi_adcs_settings.go
@@ -1,0 +1,138 @@
+// jamfproapi_adcs_settings.go
+// Jamf Pro Api - AD CS Settings
+// api reference: https://developer.jamf.com/jamf-pro/reference/post_v1-pki-adcs-settings
+// Jamf Pro API requires the structs to support a JSON data structure.
+
+package jamfpro
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const uriAdcsSettingsV1 = "/api/v1/pki/adcs-settings"
+
+// ResourceAdcsSettingsV1 represents the writable AD CS configuration payload.
+type ResourceAdcsSettingsV1 struct {
+	ID                string                     `json:"id,omitempty"`
+	DisplayName       string                     `json:"displayName,omitempty"`
+	CAName            string                     `json:"caName,omitempty"`
+	FQDN              string                     `json:"fqdn,omitempty"`
+	AdcsURL           string                     `json:"adcsUrl,omitempty"`
+	ServerCert        *ResourceAdcsCertificateV1 `json:"serverCert,omitempty"`
+	ClientCert        *ResourceAdcsCertificateV1 `json:"clientCert,omitempty"`
+	RevocationEnabled *bool                      `json:"revocationEnabled,omitempty"`
+	APIClientID       string                     `json:"apiClientId,omitempty"`
+	Outbound          *bool                      `json:"outbound,omitempty"`
+}
+
+// ResourceAdcsCertificateV1 bundles the file metadata and base64-encoded certificate.
+type ResourceAdcsCertificateV1 struct {
+	Filename string `json:"filename,omitempty"`
+	Data     []byte `json:"data,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// ResponseAdcsSettingsCreatedV1 captures the identifier returned after creating a configuration.
+type ResponseAdcsSettingsCreatedV1 struct {
+	ID   string `json:"id"`
+	Href string `json:"href"`
+}
+
+// ResponseAdcsSettingsV1 models the read-only fields returned for an AD CS configuration.
+type ResponseAdcsSettingsV1 struct {
+	ID                            string                     `json:"id"`
+	DisplayName                   string                     `json:"displayName"`
+	CAName                        string                     `json:"caName"`
+	FQDN                          string                     `json:"fqdn"`
+	AdcsURL                       string                     `json:"adcsUrl"`
+	ServerCert                    *ResponseAdcsCertificateV1 `json:"serverCert,omitempty"`
+	ClientCert                    *ResponseAdcsCertificateV1 `json:"clientCert,omitempty"`
+	RevocationEnabled             bool                       `json:"revocationEnabled"`
+	APIClientID                   string                     `json:"apiClientId"`
+	Outbound                      bool                       `json:"outbound"`
+	ConnectorLastCheckInTimestamp string                     `json:"connectorLastCheckInTimestamp"`
+}
+
+// ResponseAdcsCertificateV1 surfaces certificate details that Jamf Pro stores for AD CS.
+type ResponseAdcsCertificateV1 struct {
+	Filename       string `json:"filename"`
+	SerialNumber   string `json:"serialNumber"`
+	Subject        string `json:"subject"`
+	Issuer         string `json:"issuer"`
+	ExpirationDate string `json:"expirationDate"`
+}
+
+// CreateAdcsSettingsV1 creates an inbound or outbound AD CS configuration.
+func (c *Client) CreateAdcsSettingsV1(settings *ResourceAdcsSettingsV1) (*ResponseAdcsSettingsCreatedV1, error) {
+	endpoint := uriAdcsSettingsV1
+
+	var response ResponseAdcsSettingsCreatedV1
+	resp, err := c.HTTP.DoRequest("POST", endpoint, settings, &response)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedCreate, "AD CS settings", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &response, nil
+}
+
+// GetAdcsSettingsByIDV1 fetches a single AD CS configuration.
+func (c *Client) GetAdcsSettingsByIDV1(id string) (*ResponseAdcsSettingsV1, error) {
+	endpoint := fmt.Sprintf("%s/%s", uriAdcsSettingsV1, id)
+
+	var settings ResponseAdcsSettingsV1
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &settings)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedGetByID, "AD CS settings", id, err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &settings, nil
+}
+
+// UpdateAdcsSettingsByIDV1 updates an AD CS configuration using merge-patch semantics.
+func (c *Client) UpdateAdcsSettingsByIDV1(id string, settings *ResourceAdcsSettingsV1) error {
+	endpoint := fmt.Sprintf("%s/%s", uriAdcsSettingsV1, id)
+
+	resp, err := c.HTTP.DoRequest("PATCH", endpoint, settings, nil)
+	if err != nil && resp == nil {
+		return fmt.Errorf(errMsgFailedUpdateByID, "AD CS settings", id, err)
+	}
+
+	if resp == nil {
+		return fmt.Errorf("failed to update AD CS settings %s: nil response", id)
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to update AD CS settings %s: unexpected status code %d", id, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// DeleteAdcsSettingsByIDV1 removes an AD CS configuration when it is no longer in use.
+func (c *Client) DeleteAdcsSettingsByIDV1(id string) error {
+	endpoint := fmt.Sprintf("%s/%s", uriAdcsSettingsV1, id)
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf(errMsgFailedDeleteByID, "AD CS settings", id, err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Adds support for CRUD of PKI AD CS settings. Allows customers to implement and manage AD CS configuration via the SDK and Terraform. https://learn.jamf.com/en-US/bundle/technical-paper-integrating-ad-cs-current/page/Overview_ADCS.html

AD CS is widely employed by larger edu/enterprise orgs to distribute machine certs for Wi-Fi/VPN auth/identity etc.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
