### PR TITLE
feat: add support for /api/v1/ldap

### DIFF
--- a/examples/ldap/GetLdapGroupsV1/GetLdapGroupsV1.go
+++ b/examples/ldap/GetLdapGroupsV1/GetLdapGroupsV1.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	// Initialize the Jamf Pro client with the HTTP client configuration
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	// Optional: provide text to perform a contains search on LDAP group names
+	searchTerm := "Admin"
+
+	// Call GetLdapGroupsV1 to retrieve Jamf Pro LDAP groups
+	groups, err := client.GetLdapGroupsV1(searchTerm)
+	if err != nil {
+		log.Fatalf("Error fetching LDAP groups: %v", err)
+	}
+
+	// Pretty print the group list
+	groupsJSON, err := json.MarshalIndent(groups, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling LDAP groups data: %v", err)
+	}
+
+	fmt.Println("Fetched LDAP Groups:\n", string(groupsJSON))
+}

--- a/examples/ldap/GetLdapServersV1/GetLdapServersV1.go
+++ b/examples/ldap/GetLdapServersV1/GetLdapServersV1.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	// Define the path to the JSON configuration file
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	// Initialize the Jamf Pro client with the HTTP client configuration
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	// Call GetLdapServersV1 to retrieve LDAP and Cloud Identity Provider servers
+	servers, err := client.GetLdapServersV1()
+	if err != nil {
+		log.Fatalf("Error fetching LDAP servers: %v", err)
+	}
+
+	// Pretty print the server list
+	serversJSON, err := json.MarshalIndent(servers, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling LDAP servers data: %v", err)
+	}
+
+	fmt.Println("Fetched LDAP Servers:\n", string(serversJSON))
+}

--- a/sdk/jamfpro/jamfproapi_ldap.go
+++ b/sdk/jamfpro/jamfproapi_ldap.go
@@ -1,0 +1,85 @@
+// jamfproapi_ldap.go
+// Jamf Pro Api - LDAP
+// api reference: https://developer.jamf.com/jamf-pro/reference/get_v1-ldap-groups
+// api reference: https://developer.jamf.com/jamf-pro/reference/get_v1-ldap-servers
+// Jamf Pro Api requires the structs to support a JSON data structure.
+
+package jamfpro
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	uriLdapGroupsV1  = "/api/v1/ldap/groups"
+	uriLdapServersV1 = "/api/v1/ldap/servers"
+)
+
+// ResponseLdapGroupSearchResultsV1 models the search payload for LDAP groups.
+type ResponseLdapGroupSearchResultsV1 struct {
+	TotalCount int                   `json:"totalCount"`
+	Results    []ResourceLdapGroupV1 `json:"results"`
+}
+
+// ResourceLdapGroupV1 represents a Jamf Pro LDAP group definition.
+type ResourceLdapGroupV1 struct {
+	ID                string `json:"id"`
+	UUID              string `json:"uuid"`
+	LdapServerID      int    `json:"ldapServerId"`
+	Name              string `json:"name"`
+	DistinguishedName string `json:"distinguishedName"`
+}
+
+// ResourceLdapServerV1 represents a Jamf Pro LDAP server summary.
+type ResourceLdapServerV1 struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetLdapGroupsV1 retrieves LDAP groups whose names contain the supplied search text.
+func (c *Client) GetLdapGroupsV1(search string) (*ResponseLdapGroupSearchResultsV1, error) {
+	endpoint := uriLdapGroupsV1
+	trimmedSearch := strings.TrimSpace(search)
+
+	if trimmedSearch != "" {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build ldap groups query: %v", err)
+		}
+
+		query := u.Query()
+		query.Set("q", trimmedSearch)
+		u.RawQuery = query.Encode()
+		endpoint = u.String()
+	}
+
+	var groups ResponseLdapGroupSearchResultsV1
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &groups)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedGet, "ldap groups", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &groups, nil
+}
+
+// GetLdapServersV1 retrieves every active LDAP or cloud identity provider server definition.
+func (c *Client) GetLdapServersV1() ([]ResourceLdapServerV1, error) {
+	var servers []ResourceLdapServerV1
+
+	resp, err := c.HTTP.DoRequest("GET", uriLdapServersV1, nil, &servers)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedGet, "ldap servers", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return servers, nil
+}


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Add support for querying Directory Service Groups and servers.

This endpoint returns results from all LDAP servers and Cloud IdP integrations configured in Jamf Pro.

Use case is for upcoming PR for the provider, to check that `directory_service_usergroup_names` declared in scoping limitations/exclusions actually exist during a Terraform plan. If they do not, the plan will fail.

Without this, a plan will succeed and an apply will fail, with the API returning a 409 response when attempting to create or update the resource. 

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
