### PR TITLE
feat: add CRUD support to Cloud Distribution Point with V1 naming

### DIFF
--- a/examples/cloud_distribution_points/CreateCloudDistributionPointV1/CreateCloudDistributionPointV1.go
+++ b/examples/cloud_distribution_points/CreateCloudDistributionPointV1/CreateCloudDistributionPointV1.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	payload := &jamfpro.ResourceCloudDistributionPointV1{
+		CdnType: "JAMF_CLOUD",
+		Master:  false,
+	}
+
+	created, err := client.CreateCloudDistributionPointV1(payload)
+	if err != nil {
+		log.Fatalf("Error creating Cloud Distribution Point: %v", err)
+	}
+
+	body, err := json.MarshalIndent(created, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling response: %v", err)
+	}
+
+	fmt.Println("Created Cloud Distribution Point:\n", string(body))
+}

--- a/examples/cloud_distribution_points/DeleteCloudDistributionPointV1/DeleteCloudDistributionPointV1.go
+++ b/examples/cloud_distribution_points/DeleteCloudDistributionPointV1/DeleteCloudDistributionPointV1.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	if err := client.DeleteCloudDistributionPointV1(); err != nil {
+		log.Fatalf("Error deleting Cloud Distribution Point: %v", err)
+	}
+
+	log.Println("Cloud Distribution Point deleted successfully")
+}

--- a/examples/cloud_distribution_points/GetCloudDistributionPointTestConnectionV1/GetCloudDistributionPointTestConnectionV1.go
+++ b/examples/cloud_distribution_points/GetCloudDistributionPointTestConnectionV1/GetCloudDistributionPointTestConnectionV1.go
@@ -18,8 +18,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
-	// Call GetCloudDistributionPoints function
-	groups, err := client.GetCloudDistributionPointTestConnection()
+	// Call GetCloudDistributionPointTestConnectionV1 function
+	groups, err := client.GetCloudDistributionPointTestConnectionV1()
 	if err != nil {
 		log.Fatalf("Error fetching Cloud Distribution Point Test Connection: %v", err)
 	}

--- a/examples/cloud_distribution_points/GetCloudDistributionPointUploadCapabilityV1/GetCloudDistributionPointUploadCapabilityV1.go
+++ b/examples/cloud_distribution_points/GetCloudDistributionPointUploadCapabilityV1/GetCloudDistributionPointUploadCapabilityV1.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	// Define the path to the JSON configuration file
-	configFilePath := "/Users/dafyddwatkins/localtesting/jamfpro/clientconfig.json"
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
 
 	// Initialize the Jamf Pro client with the HTTP client configuration
 	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
@@ -18,8 +18,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
-	// Call GetCloudDistributionPoints function
-	groups, err := client.GetCloudDistributionPointUploadCapability()
+	// Call GetCloudDistributionPointUploadCapabilityV1 function
+	groups, err := client.GetCloudDistributionPointUploadCapabilityV1()
 	if err != nil {
 		log.Fatalf("Error fetching Cloud Distribution Point Upload Capability: %v", err)
 	}

--- a/examples/cloud_distribution_points/GetCloudDistributionPointV1/GetCloudDistributionPointV1.go
+++ b/examples/cloud_distribution_points/GetCloudDistributionPointV1/GetCloudDistributionPointV1.go
@@ -18,8 +18,8 @@ func main() {
 		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
 	}
 
-	// Call GetCloudDistributionPoint function
-	groups, err := client.GetCloudDistributionPoint()
+	// Call GetCloudDistributionPointV1 function
+	groups, err := client.GetCloudDistributionPointV1()
 	if err != nil {
 		log.Fatalf("Error fetching Cloud Distribution Point Details: %v", err)
 	}

--- a/examples/cloud_distribution_points/UpdateCloudDistributionPointV1/UpdateCloudDistributionPoint.go
+++ b/examples/cloud_distribution_points/UpdateCloudDistributionPointV1/UpdateCloudDistributionPoint.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	updatePayload := &jamfpro.ResourceCloudDistributionPointV1{
+		CdnType: "JAMF_CLOUD",
+		Master:  false,
+	}
+
+	updated, err := client.UpdateCloudDistributionPointV1(updatePayload)
+	if err != nil {
+		log.Fatalf("Error updating Cloud Distribution Point: %v", err)
+	}
+
+	body, err := json.MarshalIndent(updated, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling response: %v", err)
+	}
+
+	fmt.Println("Updated Cloud Distribution Point:\n", string(body))
+}

--- a/examples/cloud_distribution_points/UpdateCloudDistributionPointV1/UpdateCloudDistributionPointV1.go
+++ b/examples/cloud_distribution_points/UpdateCloudDistributionPointV1/UpdateCloudDistributionPointV1.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+)
+
+func main() {
+	configFilePath := "/Users/Shared/GitHub/go-api-sdk-jamfpro/localtesting/clientconfig.json"
+
+	client, err := jamfpro.BuildClientWithConfigFile(configFilePath)
+	if err != nil {
+		log.Fatalf("Failed to initialize Jamf Pro client: %v", err)
+	}
+
+	updatePayload := &jamfpro.ResourceCloudDistributionPointV1{
+		CdnType: "JAMF_CLOUD",
+		Master:  false,
+	}
+
+	updated, err := client.UpdateCloudDistributionPointV1(updatePayload)
+	if err != nil {
+		log.Fatalf("Error updating Cloud Distribution Point: %v", err)
+	}
+
+	body, err := json.MarshalIndent(updated, "", "    ")
+	if err != nil {
+		log.Fatalf("Error marshaling response: %v", err)
+	}
+
+	fmt.Println("Updated Cloud Distribution Point:\n", string(body))
+}

--- a/sdk/jamfpro/jamfproapi_cloud_distribution_point.go
+++ b/sdk/jamfpro/jamfproapi_cloud_distribution_point.go
@@ -11,10 +11,32 @@ import (
 
 // Responses
 
-const uriCloudDistributionPoint = "/api/v1/cloud-distribution-point"
+const uriCloudDistributionPointV1 = "/api/v1/cloud-distribution-point"
 
-// Resource
-type ResourceCloudDistributionPoint struct {
+// ResourceCloudDistributionPointV1 represents the writable payload used for both
+// POST and PATCH /v1/cloud-distribution-point. Fields marked with pointers are
+// only serialized when explicitly set, allowing partial updates while still
+// letting callers reuse the same struct for creates.
+type ResourceCloudDistributionPointV1 struct {
+	CdnType                 string `json:"cdnType"`
+	Master                  bool   `json:"master"`
+	Username                string `json:"username,omitempty"`
+	Password                string `json:"password,omitempty"`
+	Directory               string `json:"directory,omitempty"`
+	UploadUrl               string `json:"uploadUrl,omitempty"`
+	DownloadUrl             string `json:"downloadUrl,omitempty"`
+	SecondaryAuthRequired   *bool  `json:"secondaryAuthRequired,omitempty"`
+	SecondaryAuthStatusCode *int   `json:"secondaryAuthStatusCode,omitempty"`
+	SecondaryAuthTimeToLive *int   `json:"secondaryAuthTimeToLive,omitempty"`
+	RequireSignedUrls       *bool  `json:"requireSignedUrls,omitempty"`
+	KeyPairId               string `json:"keyPairId,omitempty"`
+	ExpirationSeconds       *int   `json:"expirationSeconds,omitempty"`
+	PrivateKey              string `json:"privateKey,omitempty"`
+}
+
+// ResponseCloudDistributionPointV1 models the read-only fields returned when
+// fetching the cloud distribution point configuration.
+type ResponseCloudDistributionPointV1 struct {
 	HasConnectionSucceeded  bool        `json:"hasConnectionSucceeded"`
 	Message                 string      `json:"message"`
 	InventoryId             string      `json:"inventoryId"`
@@ -34,21 +56,21 @@ type ResourceCloudDistributionPoint struct {
 	PrivateKey              interface{} `json:"privateKey"`
 }
 
-type ResourceCloudDistributionPointUploadCapability struct {
+type ResourceCloudDistributionPointUploadCapabilityV1 struct {
 	ID   bool `json:"principalDistributionTechnology"`
 	Name bool `json:"directUploadCapable"`
 }
 
-type ResourceCloudDistributionPointTestConnection struct {
+type ResourceCloudDistributionPointTestConnectionV1 struct {
 	HasConnectionSucceeded bool   `json:"hasConnectionSucceeded"`
 	Message                string `json:"message"`
 }
 
-// GetCloudDistributionPoint retrieves the default server configuration for the Cloud Distribution Point.
-func (c *Client) GetCloudDistributionPoint() (*ResourceCloudDistributionPoint, error) {
-	endpoint := uriCloudDistributionPoint
+// GetCloudDistributionPointV1 retrieves the default server configuration for the Cloud Distribution Point.
+func (c *Client) GetCloudDistributionPointV1() (*ResponseCloudDistributionPointV1, error) {
+	endpoint := uriCloudDistributionPointV1
 
-	var cloudDistributionPoint ResourceCloudDistributionPoint
+	var cloudDistributionPoint ResponseCloudDistributionPointV1
 	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &cloudDistributionPoint)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "Cloud Distribution Point", err)
@@ -61,11 +83,61 @@ func (c *Client) GetCloudDistributionPoint() (*ResourceCloudDistributionPoint, e
 	return &cloudDistributionPoint, nil
 }
 
-// GetCloudDistributionPointUploadCapability retrieves the upload capability for the Cloud Distribution Point.
-func (c *Client) GetCloudDistributionPointUploadCapability() (*ResourceCloudDistributionPointUploadCapability, error) {
-	endpoint := uriCloudDistributionPoint + "/upload-capability"
+// CreateCloudDistributionPointV1 provisions a CDN-backed cloud distribution point configuration.
+func (c *Client) CreateCloudDistributionPointV1(payload *ResourceCloudDistributionPointV1) (*ResponseCloudDistributionPointV1, error) {
+	endpoint := uriCloudDistributionPointV1
 
-	var cloudDistributionPointUploadCapability ResourceCloudDistributionPointUploadCapability
+	var created ResponseCloudDistributionPointV1
+	resp, err := c.HTTP.DoRequest("POST", endpoint, payload, &created)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedCreate, "cloud distribution point", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &created, nil
+}
+
+// UpdateCloudDistributionPointV1 performs a partial update against the current cloud distribution point configuration.
+func (c *Client) UpdateCloudDistributionPointV1(payload *ResourceCloudDistributionPointV1) (*ResponseCloudDistributionPointV1, error) {
+	endpoint := uriCloudDistributionPointV1
+
+	var updated ResponseCloudDistributionPointV1
+	resp, err := c.HTTP.DoRequest("PATCH", endpoint, payload, &updated)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgFailedUpdate, "cloud distribution point", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return &updated, nil
+}
+
+// DeleteCloudDistributionPointV1 removes the active cloud distribution point configuration.
+func (c *Client) DeleteCloudDistributionPointV1() error {
+	endpoint := uriCloudDistributionPointV1
+
+	resp, err := c.HTTP.DoRequest("DELETE", endpoint, nil, nil)
+	if err != nil {
+		return fmt.Errorf(errMsgFailedDelete, "cloud distribution point", err)
+	}
+
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// GetCloudDistributionPointUploadCapabilityV1 retrieves the upload capability for the Cloud Distribution Point.
+func (c *Client) GetCloudDistributionPointUploadCapabilityV1() (*ResourceCloudDistributionPointUploadCapabilityV1, error) {
+	endpoint := uriCloudDistributionPointV1 + "/upload-capability"
+
+	var cloudDistributionPointUploadCapability ResourceCloudDistributionPointUploadCapabilityV1
 	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &cloudDistributionPointUploadCapability)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "Cloud Distribution Point", err)
@@ -78,11 +150,11 @@ func (c *Client) GetCloudDistributionPointUploadCapability() (*ResourceCloudDist
 	return &cloudDistributionPointUploadCapability, nil
 }
 
-// GetCloudDistributionPointTestConnection retrieves the test connection status for the Cloud Distribution Point.
-func (c *Client) GetCloudDistributionPointTestConnection() (*ResourceCloudDistributionPointTestConnection, error) {
-	endpoint := uriCloudDistributionPoint + "/test-connection"
+// GetCloudDistributionPointTestConnectionV1 retrieves the test connection status for the Cloud Distribution Point.
+func (c *Client) GetCloudDistributionPointTestConnectionV1() (*ResourceCloudDistributionPointTestConnectionV1, error) {
+	endpoint := uriCloudDistributionPointV1 + "/test-connection"
 
-	var cloudDistributionPointTestConnection ResourceCloudDistributionPointTestConnection
+	var cloudDistributionPointTestConnection ResourceCloudDistributionPointTestConnectionV1
 	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &cloudDistributionPointTestConnection)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGet, "Cloud Distribution Point", err)


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Adds support for creation, update and deletion of Cloud DP. Renamed types and functions to reflect API endpoint versions. Tested with Jamf Cloud Distribution Service type.

Related to https://github.com/deploymenttheory/terraform-provider-jamfpro/issues/796

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [x] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
