### PR TITLE
feat: add SecureTokenAllowed field to PolicySubsetAccountMaintenanceAccount

### DIFF
--- a/sdk/jamfpro/classicapi_policies.go
+++ b/sdk/jamfpro/classicapi_policies.go
@@ -242,6 +242,7 @@ type PolicySubsetAccountMaintenanceAccount struct {
 	Picture                string `xml:"picture"`
 	Admin                  bool   `xml:"admin"`
 	FilevaultEnabled       bool   `xml:"filevault_enabled"`
+	SecureTokenAllowed     bool   `xml:"secure_token_allowed"`
 	PasswordSha256         string `xml:"password_sha256"`
 }
 


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Adds support for the "Allow user to be granted the first secure token" setting under Policy -> Local Accounts.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
