### PR TITLE
fix: UserLookupByEmail is a List

### DIFF
--- a/sdk/jamfpro/classicapi_users.go
+++ b/sdk/jamfpro/classicapi_users.go
@@ -29,6 +29,12 @@ type UsersListItem struct {
 	Name string `xml:"name"`
 }
 
+// Response structure for email lookup (returns full user details in a list wrapper)
+type ResponseUsersListByEmail struct {
+	Size  int            `xml:"size"`
+	Users []ResourceUser `xml:"user"`
+}
+
 // Resource
 
 type ResourceUser struct {
@@ -141,8 +147,8 @@ func (c *Client) GetUserByName(name string) (*ResourceUser, error) {
 func (c *Client) GetUserByEmail(email string) (*ResourceUser, error) {
 	endpoint := fmt.Sprintf("%s/email/%s", uriUsers, email)
 
-	var userDetail ResourceUser
-	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &userDetail)
+	var usersList ResponseUsersListByEmail
+	resp, err := c.HTTP.DoRequest("GET", endpoint, nil, &usersList)
 	if err != nil {
 		return nil, fmt.Errorf(errMsgFailedGetByEmail, "user", email, err)
 	}
@@ -151,7 +157,11 @@ func (c *Client) GetUserByEmail(email string) (*ResourceUser, error) {
 		defer resp.Body.Close()
 	}
 
-	return &userDetail, nil
+	if usersList.Size == 0 || len(usersList.Users) == 0 {
+		return nil, fmt.Errorf("user with email '%s' not found", email)
+	}
+
+	return &usersList.Users[0], nil
 }
 
 // CreateUser creates a new user.


### PR DESCRIPTION
# Change

Fixes `GetUserByEmail` - it was trying to unmarshal a list response into a single user struct, returning empty data instead of the actual user.

## Problem
The `/JSSResource/users/email/{email}` endpoint returns a different structure than the name/ID endpoints:

```xml
<users>
  <size>1</size>
  <user>...</user>
</users>
```

The SDK was expecting just <user>...</user>, so it would silently fail and return an empty user object (ID=0, blank fields).

- Added ResponseUsersListByEmail struct to handle the list wrapper
- Updated GetUserByEmail() to unmarshal the list and return the first user
- Returns an error if no users found instead of empty data

## Type of Change

Please **DELETE** options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I did format my code
