### PR TITLE
feat(computer_prestages): add Platform SSO config fields

### DIFF
--- a/sdk/jamfpro/jamfproapi_computer_prestages.go
+++ b/sdk/jamfpro/jamfproapi_computer_prestages.go
@@ -107,6 +107,9 @@ type ResourceComputerPrestage struct {
 	OnboardingItems                                []OnboardingItem                            `json:"onboardingItems,omitempty"`
 	PssoEnabled                                    *bool                                       `json:"pssoEnabled,omitempty"`
 	PlatformSsoAppBundleId                         string                                      `json:"platformSsoAppBundleId,omitempty"`
+	PssoConfigProfileId                            string                                      `json:"pssoConfigProfileId,omitempty"`
+	ManifestUrl                                    string                                      `json:"manifestUrl,omitempty"`
+	ProfileUrl                                     string                                      `json:"profileUrl,omitempty"`
 }
 
 // Subsets & Containers


### PR DESCRIPTION
Add pssoConfigProfileId, manifestUrl and profileUrl to ResourceComputerPrestage. pssoConfigProfileId distinguishes attended Platform SSO from the unattended platformSsoAppBundleId mode; manifestUrl and profileUrl are required to configure unattended Platform SSO.

# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
